### PR TITLE
Downgrade AnyCPU Error to Warning

### DIFF
--- a/gen_build.cs
+++ b/gen_build.cs
@@ -2720,9 +2720,9 @@ public static class gen
 			f.WriteAttributeString("Name", string.Format("check_cpu_{0}", Guid.NewGuid().ToString()));
 			f.WriteAttributeString("BeforeTargets", "ResolveAssemblyReferences");
 			f.WriteAttributeString("Condition", string.Format(" ( {0} ) ", cond));
-			f.WriteStartElement("Error");
+			f.WriteStartElement("Warning");
 			f.WriteAttributeString("Text", string.Format("$(Platform) is not supported. The Platform configuration must be {0}", ok));
-			f.WriteEndElement(); // Error
+			f.WriteEndElement(); // Warning
 			f.WriteEndElement(); // Target
 
 			f.WriteStartElement("Target");


### PR DESCRIPTION
In the scenario where the target is a platform-specific library (i.e. a library whose TargetFramework is Net45), it is entirely valid to link to SQLitePCL.Raw but still be AnyCPU.

This restriction should really only pop up if the target is an App, but defining that on every platform is way trickier (i.e. a unit test DLL is technically an "app" in the sense that it isn't a library being integrated as a piece of another program, and therefore should be x86 or else the tests will fail).

We're hitting this in GitHub for Windows, where our libraries are marked AnyCPU but are Net45, so they blow up. Changing them to x86 will change the ClickOnce manifest and break the installer (since architecture is part of a binary's identity in ClickOnce :man::gun:)
