### PR TITLE
Fixes callback on disposed collation delegate issue.

### DIFF
--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -490,12 +490,13 @@ namespace SQLitePCL
 #if PLATFORM_IOS
         [MonoTouch.MonoPInvokeCallback (typeof(NativeMethods.callback_collation))] // TODO not xplat
 #endif
-        static int collation_hook_bridge(IntPtr p, int len1, IntPtr pv1, int len2, IntPtr pv2)
+        static int collation_hook_bridge_impl(IntPtr p, int len1, IntPtr pv1, int len2, IntPtr pv2)
         {
             collation_hook_info hi = collation_hook_info.from_ptr(p);
             return hi.call(util.from_utf8(pv1, len1), util.from_utf8(pv2, len2));
         }
 
+        NativeMethods.callback_collation collation_hook_bridge = new NativeMethods.callback_collation(collation_hook_bridge_impl);
         int ISQLite3Provider.sqlite3_create_collation(IntPtr db, string name, object v, delegate_collation func)
         {
             if (_collation_hooks.ContainsKey(name))


### PR DESCRIPTION
Collation delegates would work fine until garbage collection ran.
The next attempt to invoke the delegate on the unmanaged side
would throw an AccessViolationException.

Explicitly creating the delegate object, and holding a reference
to it, resolves the problem.

NOTE: This fix should also be applied to the other callback delegates, like `sqlite3_commit_hook`,  `sqlite3_update_hook`, `sqlite3_rollback_hook`, `sqlite3_trace`, `sqlite3_create_function_v2`, `sqlite3_config_log`, and `sqlite3_profile`.
