### PR TITLE
Sqlite3 progress handler

### DIFF
--- a/src/cpp/sqlite3_cx.cpp
+++ b/src/cpp/sqlite3_cx.cpp
@@ -111,6 +111,11 @@ int64 SQLite3RuntimeProvider::sqlite3_profile(int64 db, int64 func, int64 v)
 	return (int64) ::sqlite3_profile((sqlite3*)db, (void(*)(void*,const char*,sqlite3_uint64)) func, (void*)v);
 }
 
+void SQLite3RuntimeProvider::sqlite3_progress_handler(int64 db, int32 instructions, int64 func, int64 v)
+{
+	::sqlite3_progress_handler((sqlite3*)db, instructions, (int(*)(void*)) func, (void*)v);
+}
+
 int32 SQLite3RuntimeProvider::sqlite3_create_collation(int64 db, int64 name, int32 textrep, int64 v, int64 func)
 {
     return ::sqlite3_create_collation((sqlite3*)db, (const char*) name, textrep, (void*) v, (int(*)(void*,int,const void*,int,const void*)) func);

--- a/src/cpp/sqlite3_cx.h
+++ b/src/cpp/sqlite3_cx.h
@@ -48,6 +48,7 @@ namespace SQLitePCL
                     static int64 sqlite3_rollback_hook(int64 db, int64 func, int64 v);
                     static int64 sqlite3_trace(int64 db, int64 func, int64 v);
                     static int64 sqlite3_profile(int64 db, int64 func, int64 v);
+                    static void sqlite3_progress_handler(int64 db, int32 instructions, int64 func, int64 v);
                     static int64 sqlite3_update_hook(int64 db, int64 func, int64 v);
                     static int32 sqlite3_create_collation(int64 db, int64 name, int32 textrep, int64 v, int64 func);
 

--- a/src/cs/isqlite3.cs
+++ b/src/cs/isqlite3.cs
@@ -31,6 +31,7 @@ namespace SQLitePCL
     public delegate void delegate_rollback(object user_data);
     public delegate void delegate_trace(object user_data, string statement);
     public delegate void delegate_profile(object user_data, string statement, long ns);
+    public delegate int delegate_progress_handler(object user_data);
     public delegate void delegate_update(object user_data, int type, string database, string table, long rowid);
     public delegate int delegate_collation(object user_data, string s1, string s2);
     public delegate int delegate_exec(object user_data, string[] values, string[] names);
@@ -169,6 +170,7 @@ namespace SQLitePCL
         void sqlite3_rollback_hook(IntPtr db, delegate_rollback func, object v);
         void sqlite3_trace(IntPtr db, delegate_trace func, object v);
         void sqlite3_profile(IntPtr db, delegate_profile func, object v);
+        void sqlite3_progress_handler(IntPtr db, int instructions, delegate_progress_handler func, object v);
         void sqlite3_update_hook(IntPtr db, delegate_update func, object v);
         int sqlite3_create_collation(IntPtr db, string name, object v, delegate_collation func);
         int sqlite3_create_function(IntPtr db, string name, int nArg, object v, delegate_function_scalar func);

--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -298,6 +298,11 @@ namespace SQLitePCL
             _imp.sqlite3_profile(db.ptr, f, v);
         }
 
+        static public void sqlite3_progress_handler(sqlite3 db, int instructions, delegate_progress_handler func, object v)
+        {
+            _imp.sqlite3_progress_handler(db.ptr, instructions, func, v);
+        }
+
         static public void sqlite3_update_hook(sqlite3 db, delegate_update f, object v)
         {
             _imp.sqlite3_update_hook(db.ptr, f, v);

--- a/src/cs/sqlite3_bait.cs
+++ b/src/cs/sqlite3_bait.cs
@@ -295,6 +295,11 @@ namespace SQLitePCL
 	    throw new Exception(GRIPE);
         }
 
+        void ISQLite3Provider.sqlite3_progress_handler(IntPtr db, int instructions, delegate_progress_handler func, object v)
+        {
+            throw new Exception(GRIPE);
+        }
+
         long ISQLite3Provider.sqlite3_memory_used()
         {
 	    throw new Exception(GRIPE);

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -529,14 +529,14 @@ namespace SQLitePCL
 
         private progress_handler_hook_info _progress_handler_hook;
 
-        static private void progress_handler_hook_bridge(IntPtr p)
+        static private int progress_handler_hook_bridge(IntPtr p)
         {
             progress_handler_hook_info hi = progress_handler_hook_info.from_ptr(p);
-            hi.call();
+            return hi.call();
         }
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        private delegate void callback_progress_handler(IntPtr p);
+        private delegate int callback_progress_handler(IntPtr p);
 
         void ISQLite3Provider.sqlite3_progress_handler(IntPtr db, int instructions, delegate_progress_handler func, object v)
         {

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -522,6 +522,43 @@ namespace SQLitePCL
             }
         }
 
+ // ----------------------------------------------------------------
+
+        // Passing a callback into SQLite is tricky.  See comments near commit_hook
+        // implementation in pinvoke/SQLite3Provider.cs
+
+        private progress_handler_hook_info _progress_handler_hook;
+
+        static private void progress_handler_hook_bridge(IntPtr p)
+        {
+            progress_handler_hook_info hi = progress_handler_hook_info.from_ptr(p);
+            hi.call();
+        }
+
+        [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
+        private delegate void callback_progress_handler(IntPtr p);
+
+        void ISQLite3Provider.sqlite3_progress_handler(IntPtr db, int instructions, delegate_progress_handler func, object v)
+        {
+            if (_progress_handler_hook != null)
+            {
+                // TODO maybe turn off the hook here, for now
+                _progress_handler_hook.free();
+                _progress_handler_hook = null;
+            }
+
+            if (func != null)
+            {
+                _progress_handler_hook = new progress_handler_hook_info(func, v);
+                SQLite3RuntimeProvider.sqlite3_progress_handler(db.ToInt64(), instructions, Marshal.GetFunctionPointerForDelegate(new callback_progress_handler(progress_handler_hook_bridge)).ToInt64(), _progress_handler_hook.ptr.ToInt64());
+            }
+            else
+            {
+                SQLite3RuntimeProvider.sqlite3_progress_handler(db.ToInt64(), instructions, IntPtr.Zero.ToInt64(), IntPtr.Zero.ToInt64());
+            }
+        }
+
+
         // ----------------------------------------------------------------
 
         int ISQLite3Provider.sqlite3_close(IntPtr db)

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -529,7 +529,7 @@ namespace SQLitePCL
 
         private progress_handler_hook_info _progress_handler_hook;
 
-        static private int progress_handler_hook_bridge(IntPtr p)
+        static private int progress_handler_hook_bridge_impl(IntPtr p)
         {
             progress_handler_hook_info hi = progress_handler_hook_info.from_ptr(p);
             return hi.call();
@@ -537,6 +537,8 @@ namespace SQLitePCL
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         private delegate int callback_progress_handler(IntPtr p);
+
+        callback_progress_handler progress_handler_hook_bridge = new callback_progress_handler(progress_handler_hook_bridge_impl);
 
         void ISQLite3Provider.sqlite3_progress_handler(IntPtr db, int instructions, delegate_progress_handler func, object v)
         {
@@ -550,7 +552,7 @@ namespace SQLitePCL
             if (func != null)
             {
                 _progress_handler_hook = new progress_handler_hook_info(func, v);
-                SQLite3RuntimeProvider.sqlite3_progress_handler(db.ToInt64(), instructions, Marshal.GetFunctionPointerForDelegate(new callback_progress_handler(progress_handler_hook_bridge)).ToInt64(), _progress_handler_hook.ptr.ToInt64());
+                SQLite3RuntimeProvider.sqlite3_progress_handler(db.ToInt64(), instructions, Marshal.GetFunctionPointerForDelegate(progress_handler_hook_bridge).ToInt64(), _progress_handler_hook.ptr.ToInt64());
             }
             else
             {

--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -797,12 +797,12 @@ namespace SQLitePCL
         private progress_handler_hook_info _progress_handler_hook;
 
 #if PLATFORM_IOS || PLATFORM_UNIFIED
-        [MonoPInvokeCallback (typeof(NativeMethods.callback_profile))] // TODO not xplat
+        [MonoPInvokeCallback (typeof(NativeMethods.callback_progress_handler))] // TODO not xplat
 #endif
-        static void progress_handler_hook_bridge_impl(IntPtr p)
+        static int progress_handler_hook_bridge_impl(IntPtr p)
         {
             progress_handler_hook_info hi = progress_handler_hook_info.from_ptr(p);
-            hi.call();
+            return hi.call();
         }
 
         NativeMethods.callback_progress_handler progress_handler_hook_bridge = new NativeMethods.callback_progress_handler(progress_handler_hook_bridge_impl);
@@ -1533,7 +1533,7 @@ namespace SQLitePCL
             public static extern IntPtr sqlite3_profile(IntPtr db, callback_profile func, IntPtr pvUser);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            public delegate void callback_progress_handler(IntPtr puser);
+            public delegate int callback_progress_handler(IntPtr puser);
 
             [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr sqlite3_progress_handler(IntPtr db, int instructions, callback_progress_handler func, IntPtr pvUser);

--- a/src/cs/test_cases.cs
+++ b/src/cs/test_cases.cs
@@ -910,6 +910,9 @@ namespace SQLitePCL.Test
                     };
 
                 raw.sqlite3_progress_handler(db, 1, handler, "user_data");
+                
+                GC.Collect();
+
                 using (sqlite3_stmt stmt = db.prepare("SELECT 1;"))
                 {
                     stmt.step();

--- a/src/cs/util.cs
+++ b/src/cs/util.cs
@@ -267,6 +267,49 @@ namespace SQLitePCL
         }
     };
 
+    internal class progress_handler_hook_info
+    {
+        private delegate_progress_handler _func;
+        private object _user_data;
+        private GCHandle _h;
+
+        internal progress_handler_hook_info(delegate_progress_handler func, object v)
+        {
+            _func = func;
+            _user_data = v;
+
+            _h = GCHandle.Alloc(this);
+        }
+
+        internal IntPtr ptr
+        {
+            get
+            {
+                return (IntPtr)_h;
+            }
+        }
+
+        internal static progress_handler_hook_info from_ptr(IntPtr p)
+        {
+            GCHandle h = (GCHandle)p;
+            progress_handler_hook_info hi = h.Target as progress_handler_hook_info;
+            // TODO assert(hi._h == h)
+            return hi;
+        }
+
+        internal void call()
+        {
+            _func(_user_data);
+        }
+
+        internal void free()
+        {
+            _func = null;
+            _user_data = null;
+            _h.Free();
+        }
+    };
+
     internal class update_hook_info
     {
         private delegate_update _func;

--- a/src/cs/util.cs
+++ b/src/cs/util.cs
@@ -297,9 +297,9 @@ namespace SQLitePCL
             return hi;
         }
 
-        internal void call()
+        internal int call()
         {
-            _func(_user_data);
+            return _func(_user_data);
         }
 
         internal void free()


### PR DESCRIPTION
Related to my sqlite3_interrupt PR. I found a mailing list thread suggesting this as an alternative to sqlite3_interrupt when only canceling the currently executing statement is desired. I think it would be prudent to add both to the library.