### PR TITLE
Support sqlite3_table_column_metadata.

### DIFF
--- a/src/cpp/sqlite3_cx.cpp
+++ b/src/cpp/sqlite3_cx.cpp
@@ -162,6 +162,51 @@ int64 SQLite3RuntimeProvider::sqlite3_compileoption_get(int32 n)
     return (int64) ::sqlite3_compileoption_get(n);
 }
 
+int32 SQLite3RuntimeProvider::sqlite3_table_column_metadata(int64 db, int64 dbName, int64 tableName, int64 columnName, int64 dataType, int64 collSeq, int64 notNull, int64 primaryKey, int64 autoInc)
+{
+	const char* pzDataType = nullptr;
+	const char* pzCollSeq = nullptr;
+	int32 pNotNull = 0;
+	int32 pPrimaryKey = 0;
+	int32 pAutoinc = 0;
+
+	int32 result = ::sqlite3_table_column_metadata(
+		((sqlite3 *) db), ((const char *) dbName), ((const char *) tableName), ((const char *) columnName), 
+		&pzDataType, &pzCollSeq, &pNotNull, &pPrimaryKey, &pAutoinc);
+
+	if (dataType)
+	{
+		int64* p = (int64*)dataType;
+		*p = (int64)pzDataType;
+	}
+
+	if (collSeq)
+	{
+		int64* p = (int64*)collSeq;
+		*p = (int64)pzCollSeq;
+	}
+
+	if (notNull)
+	{
+		int64* p = (int64*)notNull;
+		*p = pNotNull;
+	}
+
+	if (primaryKey)
+	{
+		int64* p = (int64*)primaryKey;
+		*p = pPrimaryKey;
+	}
+
+	if (autoInc)
+	{
+		int64* p = (int64*)autoInc;
+		*p = pAutoinc;
+	}
+
+	return result;
+}
+
 int32 SQLite3RuntimeProvider::sqlite3_prepare_v2(int64 db, int64 zSql, int32 nByte, int64 ppStmpt, int64 ppTail)
 {
 	sqlite3_stmt* sqlite3_stmt = nullptr;

--- a/src/cpp/sqlite3_cx.h
+++ b/src/cpp/sqlite3_cx.h
@@ -56,6 +56,8 @@ namespace SQLitePCL
                     static int32 sqlite3_compileoption_used(int64 s);
                     static int64 sqlite3_compileoption_get(int32 n);
 
+                    static int32 sqlite3_table_column_metadata(int64 db, int64 dbName, int64 tableName, int64 columnName, int64 dataType, int64 collSeq, int64 notNull, int64 primaryKey, int64 autoInc);
+
                     static int32 sqlite3_complete(int64 sql);
 
 					static int32 sqlite3_prepare_v2(int64 db, int64 zSql, int32 nByte, int64 ppStmpt, int64 pzTail);

--- a/src/cs/isqlite3.cs
+++ b/src/cs/isqlite3.cs
@@ -208,10 +208,7 @@ namespace SQLitePCL
         int sqlite3_wal_checkpoint(IntPtr db, string dbName);
         int sqlite3_wal_checkpoint_v2(IntPtr db, string dbName, int eMode, out int logSize, out int framesCheckPointed);
 
-#if not
-        int sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out IntPtr ptrDataType, out IntPtr ptrCollSeq, out int notNull, out int primaryKey, out int autoInc);
-
-#endif
+        int sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc);
 
 #if not // maybe never
 

--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -447,6 +447,12 @@ namespace SQLitePCL
             return _imp.sqlite3_compileoption_get(n);
         }
 
+        static public int sqlite3_table_column_metadata(sqlite3 db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc)
+        {
+
+            return _imp.sqlite3_table_column_metadata(db.ptr, dbName, tblName, colName, out dataType, out collSeq, out notNull, out primaryKey, out autoInc);
+        }
+        
         static public string sqlite3_sql(sqlite3_stmt stmt)
         {
             return _imp.sqlite3_sql(stmt.ptr);

--- a/src/cs/sqlite3_bait.cs
+++ b/src/cs/sqlite3_bait.cs
@@ -95,6 +95,11 @@ namespace SQLitePCL
 	    throw new Exception(GRIPE);
         }
 
+        int ISQLite3Provider.sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc)
+        {
+            throw new Exception(GRIPE);
+        }
+
         int ISQLite3Provider.sqlite3_prepare_v2(IntPtr db, string sql, out IntPtr stm, out string remain)
         {
 	    throw new Exception(GRIPE);

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -605,7 +605,6 @@ namespace SQLitePCL
 
         int ISQLite3Provider.sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc)
         {
-            /*
             // TODO null string?
             GCHandle db_name_pinned = GCHandle.Alloc(util.to_utf8(dbName), GCHandleType.Pinned);
             IntPtr db_name_ptr = db_name_pinned.AddrOfPinnedObject();
@@ -626,14 +625,20 @@ namespace SQLitePCL
             GCHandle buf_coll_seq_pinned = GCHandle.Alloc(buf_coll_seq, GCHandleType.Pinned);
             IntPtr buf_coll_seq_ptr = buf_coll_seq_pinned.AddrOfPinnedObject();
 
-            IntPtr buf_not_null_ptr = new IntPtr(&notNull) 
+            int buf_not_null = 0;
+            GCHandle buf_not_null_pinned = GCHandle.Alloc(buf_not_null, GCHandleType.Pinned);
+            IntPtr buf_not_null_ptr = buf_not_null_pinned.AddrOfPinnedObject();
 
-            IntPtr buf_primary_key_ptr = new IntPtr(&primaryKey); 
+            int buf_primary_key = 0;
+            GCHandle buf_primary_key_pinned = GCHandle.Alloc(buf_primary_key, GCHandleType.Pinned);
+            IntPtr buf_primary_key_ptr = buf_primary_key_pinned.AddrOfPinnedObject();
 
-            IntPtr buf_auto_inc_ptr = new IntPtr(&autoInc);
+            int buf_auto_inc = 0;
+            GCHandle buf_auto_inc_pinned = GCHandle.Alloc(buf_auto_inc, GCHandleType.Pinned);
+            IntPtr buf_auto_inc_ptr = buf_auto_inc_pinned.AddrOfPinnedObject();
 
             int rc = SQLite3RuntimeProvider.sqlite3_table_column_metadata(
-                        ptr.ToInt64(), db_name_ptr.ToInt64(), tbl_name_ptr.ToInt64(), col_name_ptr.ToInt64(),
+                        db.ToInt64(), db_name_ptr.ToInt64(), tbl_name_ptr.ToInt64(), col_name_ptr.ToInt64(),
                         buf_data_type_ptr.ToInt64(), buf_coll_seq_ptr.ToInt64(), buf_not_null_ptr.ToInt64(), buf_primary_key_ptr.ToInt64(), buf_auto_inc_ptr.ToInt64());  
 
             col_name_pinned.Free();
@@ -658,7 +663,7 @@ namespace SQLitePCL
             long collSeqPtr = Marshal.ReadInt64(buf_coll_seq_ptr);
             if (collSeqPtr == 0)
             {
-                collSeqType = null;
+                collSeq = null;
             }
             else
             {
@@ -670,18 +675,16 @@ namespace SQLitePCL
             }
             buf_coll_seq_pinned.Free();
 
-                       
+            notNull = Marshal.ReadInt32(buf_not_null_ptr);
+            buf_not_null_pinned.Free();
+
+            primaryKey = Marshal.ReadInt32(buf_primary_key_ptr);
+            buf_primary_key_pinned.Free();
+
+            autoInc = Marshal.ReadInt32(buf_auto_inc_ptr);
+            buf_auto_inc_pinned.Free();
 
             return rc;
-             * 
-             */
-
-            dataType = null;
-            collSeq = null;
-            notNull = 0;
-            primaryKey = 0;
-            autoInc = 0;
-            return -1;
         }
 
         int ISQLite3Provider.sqlite3_complete(string sql)

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -603,6 +603,87 @@ namespace SQLitePCL
             return rc;
         }
 
+        int ISQLite3Provider.sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc)
+        {
+            /*
+            // TODO null string?
+            GCHandle db_name_pinned = GCHandle.Alloc(util.to_utf8(dbName), GCHandleType.Pinned);
+            IntPtr db_name_ptr = db_name_pinned.AddrOfPinnedObject();
+
+            // TODO null string?
+            GCHandle tbl_name_pinned = GCHandle.Alloc(util.to_utf8(tblName), GCHandleType.Pinned);
+            IntPtr tbl_name_ptr = tbl_name_pinned.AddrOfPinnedObject();
+
+            // TODO null string?
+            GCHandle col_name_pinned = GCHandle.Alloc(util.to_utf8(colName), GCHandleType.Pinned);
+            IntPtr col_name_ptr = col_name_pinned.AddrOfPinnedObject();
+
+            byte[] buf_data_type = new byte[8];
+            GCHandle buf_data_type_pinned = GCHandle.Alloc(buf_data_type, GCHandleType.Pinned);
+            IntPtr buf_data_type_ptr = buf_data_type_pinned.AddrOfPinnedObject();
+
+            byte[] buf_coll_seq = new byte[8];
+            GCHandle buf_coll_seq_pinned = GCHandle.Alloc(buf_coll_seq, GCHandleType.Pinned);
+            IntPtr buf_coll_seq_ptr = buf_coll_seq_pinned.AddrOfPinnedObject();
+
+            IntPtr buf_not_null_ptr = new IntPtr(&notNull) 
+
+            IntPtr buf_primary_key_ptr = new IntPtr(&primaryKey); 
+
+            IntPtr buf_auto_inc_ptr = new IntPtr(&autoInc);
+
+            int rc = SQLite3RuntimeProvider.sqlite3_table_column_metadata(
+                        ptr.ToInt64(), db_name_ptr.ToInt64(), tbl_name_ptr.ToInt64(), col_name_ptr.ToInt64(),
+                        buf_data_type_ptr.ToInt64(), buf_coll_seq_ptr.ToInt64(), buf_not_null_ptr.ToInt64(), buf_primary_key_ptr.ToInt64(), buf_auto_inc_ptr.ToInt64());  
+
+            col_name_pinned.Free();
+            tbl_name_pinned.Free();
+            db_name_pinned.Free();
+
+            long dataTypePtr = Marshal.ReadInt64(buf_data_type_ptr);
+            if (dataTypePtr == 0)
+            {
+                dataType = null;
+            }
+            else
+            {
+                dataType = util.from_utf8(new IntPtr(dataTypePtr));
+                if (dataType.Length == 0)
+                {
+                    dataType = null;
+                }
+            }
+            buf_data_type_pinned.Free();
+
+            long collSeqPtr = Marshal.ReadInt64(buf_coll_seq_ptr);
+            if (collSeqPtr == 0)
+            {
+                collSeqType = null;
+            }
+            else
+            {
+                collSeq = util.from_utf8(new IntPtr(collSeqPtr));
+                if (collSeq.Length == 0)
+                {
+                    collSeq = null;
+                }
+            }
+            buf_coll_seq_pinned.Free();
+
+                       
+
+            return rc;
+             * 
+             */
+
+            dataType = null;
+            collSeq = null;
+            notNull = 0;
+            primaryKey = 0;
+            autoInc = 0;
+            return -1;
+        }
+
         int ISQLite3Provider.sqlite3_complete(string sql)
         {
             // TODO null string?

--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -214,6 +214,44 @@ namespace SQLitePCL
             return NativeMethods.sqlite3_compileoption_used(util.to_utf8(s));
         }
 
+        int ISQLite3Provider.sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc)
+        {
+            IntPtr datatype_ptr;
+            IntPtr collseq_ptr;
+
+            int rc = NativeMethods.sqlite3_table_column_metadata(
+                        db, util.to_utf8(dbName), util.to_utf8(tblName), util.to_utf8(colName), 
+                        out datatype_ptr, out collseq_ptr, out notNull, out primaryKey, out autoInc);
+
+            if (datatype_ptr == IntPtr.Zero)
+            {
+                dataType = null;
+            }
+            else
+            {
+                dataType = util.from_utf8(datatype_ptr);
+                if (dataType.Length == 0)
+                {
+                    dataType = null;
+                }
+            }
+
+            if (collseq_ptr == IntPtr.Zero)
+            {
+                collSeq = null;
+            }
+            else
+            {
+                collSeq = util.from_utf8(collseq_ptr);
+                if (collSeq.Length == 0)
+                {
+                    collSeq = null;
+                }
+            }         
+  
+            return rc; 
+        }
+
         int ISQLite3Provider.sqlite3_prepare_v2(IntPtr db, string sql, out IntPtr stm, out string remain)
         {
             IntPtr tail;

--- a/src/cs/test_cases.cs
+++ b/src/cs/test_cases.cs
@@ -836,6 +836,36 @@ namespace SQLitePCL.Test
                 }
             }
         }
+
+        [TestMethod]
+        public void test_table_column_metadata()
+        {
+            using (sqlite3 db = ugly.open(":memory:"))
+            {
+                // out string dataType, out string collSeq, out int notNull, out int primaryKey, out int autoInc
+                db.exec("CREATE TABLE foo (rowid integer primary key asc autoincrement, x int not null);");
+
+                string dataType;
+                string collSeq;
+                int notNull;
+                int primaryKey;
+                int autoInc;
+
+                raw.sqlite3_table_column_metadata(db, "main", "foo", "x", out dataType, out collSeq, out notNull, out primaryKey, out autoInc);
+                Assert.AreEqual(dataType, "int");
+                Assert.AreEqual(collSeq, "BINARY");
+                Assert.IsTrue(notNull > 0);
+                Assert.AreEqual(primaryKey, 0);
+                Assert.AreEqual(autoInc, 0);
+
+                raw.sqlite3_table_column_metadata(db, "main", "foo", "rowid", out dataType, out collSeq, out notNull, out primaryKey, out autoInc);
+                Assert.AreEqual(dataType, "integer");
+                Assert.AreEqual(collSeq, "BINARY");
+                Assert.AreEqual(notNull, 0);
+                Assert.IsTrue(primaryKey > 0);
+                Assert.IsTrue(primaryKey > 0);
+            }
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
Work in progress. I will add unit tests. I was wondering if you could provide me feedback/examples on the best way to pass "out int" parameters to the cpp implementation .  I didn't see any other examples of APIs with "out int" in the library.