### PR TITLE
Return null from db_filename for memory databases.

### DIFF
--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -742,7 +742,7 @@ namespace SQLitePCL
 	    {
 		    result = util.from_utf8(new IntPtr(SQLite3RuntimeProvider.sqlite3_db_filename(db.ToInt64(), IntPtr.Zero.ToInt64())));
 	    }
-	    return result;
+            return result.Length == 0 ? null : result;
 	}
 
         string ISQLite3Provider.sqlite3_errmsg(IntPtr db)

--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -311,9 +311,10 @@ namespace SQLitePCL
         }
 
         string ISQLite3Provider.sqlite3_db_filename(IntPtr db, string att)
-	{
-            return util.from_utf8(NativeMethods.sqlite3_db_filename(db, util.to_utf8(att)));
-	}
+        {
+            string retval = util.from_utf8(NativeMethods.sqlite3_db_filename(db, util.to_utf8(att)));
+            return retval.Length == 0 ? null : retval; 
+        }
 
         string ISQLite3Provider.sqlite3_errmsg(IntPtr db)
         {

--- a/src/cs/test_cases.cs
+++ b/src/cs/test_cases.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using SQLitePCL;
 using SQLitePCL.Ugly;
@@ -367,20 +368,38 @@ namespace SQLitePCL.Test
         public void test_create_table_file()
         {
 	    string name;
+            string filename;
             using (sqlite3 db = ugly.open(":memory:"))
             {
                 name = "tmp" + db.query_scalar<string>("SELECT lower(hex(randomblob(16)));");
             }
-	    string filename;
+            
             using (sqlite3 db = ugly.open(name))
 	    {
                 db.exec("CREATE TABLE foo (x int);");
 		filename = db.db_filename("main");
 	    }
 
-	    // TODO verify the filename is what we expect
-
 	    ugly.vfs__delete(null, filename, 1);
+        }
+
+        [TestMethod]
+        public void test_db_filename()
+        {
+            using (sqlite3 db = ugly.open(":memory:"))
+            {
+                db.exec("CREATE TABLE foo (x int);");
+                string filename = db.db_filename("main");
+                Assert.IsNull(filename);
+            }
+            var tempFile = Path.GetTempFileName();
+            using (sqlite3 db = ugly.open(tempFile))
+            {
+                db.exec("CREATE TABLE foo (x int);");
+                string filename = db.db_filename("main"); 
+                Assert.AreEqual(tempFile, filename);
+            }
+            File.Delete(tempFile);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes: https://github.com/ericsink/SQLitePCL.raw/issues/13