### PR TITLE
Add wal* methods.

### DIFF
--- a/src/cpp/sqlite3_cx.cpp
+++ b/src/cpp/sqlite3_cx.cpp
@@ -568,4 +568,37 @@ int32 SQLite3RuntimeProvider::sqlite3_clear_bindings(int64 stmHandle)
 int32 SQLite3RuntimeProvider::sqlite3_finalize(int64 stmHandle)
 {
 	return ::sqlite3_finalize((sqlite3_stmt*)stmHandle);
-}    
+}
+
+int32 SQLite3RuntimeProvider::sqlite3_wal_autocheckpoint(int64 db, int32 n)
+{
+	return ::sqlite3_wal_autocheckpoint((sqlite3*)db, n);
+}
+
+int32 SQLite3RuntimeProvider::sqlite3_wal_checkpoint(int64 db, int64 dbName)
+{
+	return ::sqlite3_wal_checkpoint((sqlite3*)db, (const char*)dbName);
+}
+
+int32 SQLite3RuntimeProvider::sqlite3_wal_checkpoint_v2(int64 db, int64 dbName, int32 eMode, int64 logSize, int64 framesCheckPointed)
+{
+	int32 pnLog = 0;
+	int32 pnCkpt = 0;
+
+	int32 result = ::sqlite3_wal_checkpoint_v2((sqlite3*)db, (const char *)dbName, eMode, &pnLog, &pnCkpt);
+
+	if (logSize)
+	{
+		int64* p = (int64*)logSize;
+		*p = pnLog;
+	}
+
+	if (framesCheckPointed)
+	{
+		int64* p = (int64*)framesCheckPointed;
+		*p = pnCkpt;
+	}
+
+	return result;
+}
+    

--- a/src/cpp/sqlite3_cx.h
+++ b/src/cpp/sqlite3_cx.h
@@ -185,7 +185,13 @@ namespace SQLitePCL
 
 					static int32 sqlite3_clear_bindings(int64 stmHandle);
 
-					static int32 sqlite3_finalize(int64 stmHandle);    
+					static int32 sqlite3_finalize(int64 stmHandle);
+
+					static int32 sqlite3_wal_autocheckpoint(int64 db, int32 n);
+
+					static int32 sqlite3_wal_checkpoint(int64 db, int64 dbName);
+
+					static int32 sqlite3_wal_checkpoint_v2(int64 db, int64 dbName, int32 eMode, int64 logSize, int64 framesCheckPointed);
 				};
 	}
 }

--- a/src/cs/isqlite3.cs
+++ b/src/cs/isqlite3.cs
@@ -200,6 +200,10 @@ namespace SQLitePCL
         int sqlite3_compileoption_used(string sql);
         string sqlite3_compileoption_get(int n);
 
+        int sqlite3_wal_autocheckpoint(IntPtr db, int n);
+        int sqlite3_wal_checkpoint(IntPtr db, string dbName);
+        int sqlite3_wal_checkpoint_v2(IntPtr db, string dbName, int eMode, out int logSize, out int framesCheckPointed);
+
 #if not
         int sqlite3_table_column_metadata(IntPtr db, string dbName, string tblName, string colName, out IntPtr ptrDataType, out IntPtr ptrCollSeq, out int notNull, out int primaryKey, out int autoInc);
 

--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -207,6 +207,10 @@ namespace SQLitePCL
         public const int SQLITE_COPY                  = 0;    /* No longer used */
         public const int SQLITE_RECURSIVE             = 33;   /* NULL            NULL            */
 
+        public const int SQLITE_CHECKPOINT_PASSIVE    = 0;
+        public const int SQLITE_CHECKPOINT_FULL       = 1;
+        public const int SQLITE_CHECKPOINT_RESTART    = 2;
+
         static public int sqlite3_open(string filename, out sqlite3 db)
         {
             IntPtr p;

--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -740,7 +740,20 @@ namespace SQLitePCL
             return _imp.sqlite3_blob_read(blob.ptr, b, bOffset, n, offset);
         }
 
-    }
+        static public int sqlite3_wal_autocheckpoint(sqlite3 db, int n)
+        {
+            return _imp.sqlite3_wal_autocheckpoint(db.ptr, n);
+        }
 
+        static public int sqlite3_wal_checkpoint(sqlite3 db, string dbName)
+        {
+            return _imp.sqlite3_wal_checkpoint(db.ptr, dbName);
+        }
+
+        static public int sqlite3_wal_checkpoint_v2(sqlite3 db, string dbName, int eMode, out int logSize, out int framesCheckPointed)
+        {
+            return _imp.sqlite3_wal_checkpoint_v2(db.ptr, dbName, eMode, out logSize, out framesCheckPointed);
+        }
+    }
 }
 

--- a/src/cs/sqlite3_bait.cs
+++ b/src/cs/sqlite3_bait.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
    Copyright 2014 Zumero, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -505,5 +505,19 @@ namespace SQLitePCL
 	    throw new Exception(GRIPE);
         }
 
+        int ISQLite3Provider.sqlite3_wal_autocheckpoint(IntPtr db, int n)
+        {
+            throw new Exception(GRIPE);
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint(IntPtr db, string dbName)
+        {
+            throw new Exception(GRIPE);
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint_v2(IntPtr db, string dbName, int eMode, out int logSize, out int framesCheckPointed)
+        {
+            throw new Exception(GRIPE);
+        }
     }
 }

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -1125,5 +1125,47 @@ namespace SQLitePCL
         {
             return SQLite3RuntimeProvider.sqlite3_finalize(stm.ToInt64());
         }
+
+        int ISQLite3Provider.sqlite3_wal_autocheckpoint(IntPtr db, int n)
+        {
+            return SQLite3RuntimeProvider.sqlite3_wal_autocheckpoint(db.ToInt64(), n);
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint(IntPtr db, string dbName)
+        {
+            // TODO null string?
+            GCHandle db_name_ptr_pinned = GCHandle.Alloc(util.to_utf8(dbName), GCHandleType.Pinned);
+            IntPtr db_name_ptr = db_name_ptr_pinned.AddrOfPinnedObject();
+            int result = SQLite3RuntimeProvider.sqlite3_wal_checkpoint(db.ToInt64(), db_name_ptr.ToInt64());
+            db_name_ptr_pinned.Free();
+            return result;
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint_v2(IntPtr db, string dbName, int eMode, out int logSize, out int framesCheckPointed)
+        {
+            // TODO null string?
+            GCHandle db_name_ptr_pinned = GCHandle.Alloc(util.to_utf8(dbName), GCHandleType.Pinned);
+            IntPtr db_name_ptr = db_name_ptr_pinned.AddrOfPinnedObject();
+
+            int buf_log_size = 0;
+            GCHandle buf_log_size_pinned = GCHandle.Alloc(buf_log_size, GCHandleType.Pinned);
+            IntPtr buf_log_size_ptr = buf_log_size_pinned.AddrOfPinnedObject();
+            
+            int buf_frames_check_pointed = 0;
+            GCHandle buf_frames_check_pointed_pinned = GCHandle.Alloc(buf_frames_check_pointed, GCHandleType.Pinned);
+            IntPtr buf_frames_check_pointed_ptr = buf_frames_check_pointed_pinned.AddrOfPinnedObject();
+
+            int result = SQLite3RuntimeProvider.sqlite3_wal_checkpoint_v2(db.ToInt64(), db_name_ptr.ToInt64(), eMode, buf_log_size_ptr.ToInt64(), buf_frames_check_pointed_ptr.ToInt64());
+
+            framesCheckPointed = Marshal.ReadInt32(buf_frames_check_pointed_ptr);
+            buf_frames_check_pointed_pinned.Free();
+
+            logSize = Marshal.ReadInt32(buf_log_size_ptr);
+            buf_log_size_pinned.Free();
+
+            db_name_ptr_pinned.Free();
+
+            return result;
+        }
     }
 }

--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -945,6 +945,21 @@ namespace SQLitePCL
             return NativeMethods.sqlite3_finalize(stm);
         }
 
+        int ISQLite3Provider.sqlite3_wal_autocheckpoint(IntPtr db, int n)
+        {
+            return NativeMethods.sqlite3_wal_autocheckpoint(db, n);
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint(IntPtr db, string dbName)
+        {
+            return NativeMethods.sqlite3_wal_checkpoint(db, util.to_utf8(dbName));
+        }
+
+        int ISQLite3Provider.sqlite3_wal_checkpoint_v2(IntPtr db, string dbName, int eMode, out int logSize, out int framesCheckPointed)
+        {
+            return NativeMethods.sqlite3_wal_checkpoint_v2(db, util.to_utf8(dbName), eMode, out logSize, out framesCheckPointed);
+        }
+
         private static class NativeMethods
         {
 #if PINVOKE_FROM_INTERNAL
@@ -1362,6 +1377,15 @@ namespace SQLitePCL
 
             [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
             public static extern int sqlite3_blob_close(IntPtr blob);
+
+            [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int sqlite3_wal_autocheckpoint(IntPtr db, int n);
+
+            [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int sqlite3_wal_checkpoint(IntPtr db, byte[] dbName);
+
+            [DllImport(SQLITE_DLL, CallingConvention = CallingConvention.Cdecl)]
+            public static extern int sqlite3_wal_checkpoint_v2(IntPtr db, byte[] dbName, int eMode, out int logSize, out int framesCheckPointed);
 
 #if NETFX_CORE
             [DllImport(SQLITE_DLL, EntryPoint = "sqlite3_win32_set_directory", CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Unicode)]

--- a/src/cs/test_cases.cs
+++ b/src/cs/test_cases.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using SQLitePCL;
 using SQLitePCL.Ugly;
@@ -610,6 +611,46 @@ namespace SQLitePCL.Test
                     }
                 }
             }
+        }
+
+        [TestMethod]
+        public void test_wal()
+        {
+            var tmpFile = Path.GetTempFileName();
+            using (sqlite3 db = ugly.open(tmpFile))
+            {
+                db.exec("PRAGMA journal_mode=WAL;");
+
+                // CREATE TABLE results in 2 frames check pointed and increaseses the log size by 2
+                // so manually do a checkpoint to reset the counters thus testing both
+                // sqlite3_wal_checkpoint and sqlite3_wal_checkpoint_v2.
+                db.exec("CREATE TABLE foo (x int);");
+                db.wal_checkpoint("main");
+                
+                db.exec("INSERT INTO foo (x) VALUES (1);");
+                db.exec("INSERT INTO foo (x) VALUES (2);");
+
+                int logSize;
+                int framesCheckPointed;
+                db.wal_checkpoint("main", raw.SQLITE_CHECKPOINT_FULL, out logSize, out framesCheckPointed);
+
+                Assert.AreEqual(2, logSize);
+                Assert.AreEqual(2, framesCheckPointed);
+
+                // Set autocheckpoint to 1 so that regardless of the number of 
+                // commits, explicit checkpoints only checkpoint the last update.
+                db.wal_autocheckpoint(1);
+
+                db.exec("INSERT INTO foo (x) VALUES (3);");
+                db.exec("INSERT INTO foo (x) VALUES (4);");
+                db.exec("INSERT INTO foo (x) VALUES (5);");
+                db.wal_checkpoint("main", raw.SQLITE_CHECKPOINT_PASSIVE, out logSize, out framesCheckPointed);
+
+                Assert.AreEqual(1, logSize);
+                Assert.AreEqual(1, framesCheckPointed);
+            }
+
+            ugly.vfs__delete(null, tmpFile, 1);
         }
     }
 

--- a/src/cs/ugly.cs
+++ b/src/cs/ugly.cs
@@ -345,6 +345,24 @@ namespace SQLitePCL.Ugly
             check_ok(rc);
         }
 
+        public static void wal_autocheckpoint(this sqlite3 db, int n)
+        {
+            int rc = raw.sqlite3_wal_autocheckpoint(db, n);
+            check_ok(rc);
+        }
+
+        public static void wal_checkpoint(this sqlite3 db, string dbName)
+        {
+            int rc = raw.sqlite3_wal_checkpoint(db, dbName);
+            check_ok(rc);
+        }
+
+        public static void wal_checkpoint(this sqlite3 db, string dbName, int eMode, out int logSize, out int framesCheckPointed)
+        {
+            int rc = raw.sqlite3_wal_checkpoint_v2(db, dbName, eMode, out logSize, out framesCheckPointed);
+            check_ok(rc);
+        }
+
         public static int step(this sqlite3_stmt stmt)
         {
             int rc = raw.sqlite3_step(stmt);


### PR DESCRIPTION
First run at adding the write ahead log methods. I plan to add tests as well. 

I looked into adding support for sqlite3_wal_hook but its a bit more difficult since the callback includes a database pointer, which would require additional plumbing to maintain a unique pointer per db. An alternative would be to punt on that parameter, since C# clients can use closure to capture the db if needed.