### PR TITLE
Fix exception in library initialization in mono

### DIFF
--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -1233,9 +1233,17 @@ namespace SQLitePCL
 	    }
 
 	    const uint LOAD_WITH_ALTERED_SEARCH_PATH = 8;
+	    try
+	    {
 
-            var ptr = LoadLibraryEx(dllPath, IntPtr.Zero, LOAD_WITH_ALTERED_SEARCH_PATH);
-            return ptr != IntPtr.Zero;
+	            var ptr = LoadLibraryEx(dllPath, IntPtr.Zero, LOAD_WITH_ALTERED_SEARCH_PATH);
+	            return ptr != IntPtr.Zero;
+	    }
+	    catch (Exception e)
+	    {
+	            System.Diagnostics.Debug.WriteLine(e);
+	            return false;
+	    }
         }
 
         static NativeMethods()


### PR DESCRIPTION
In mono TryLoadFromDirectory throws an Exception.
Added a try/catch to avoid the crash.