### PR TITLE
proof of concept to reduce reliance on internal memory structure related to issue #57

### DIFF
--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -31,6 +31,8 @@ namespace SQLitePCL
     {
         private static ISQLite3Provider _imp = new SQLite3Provider();
 
+        public static bool enable_library_support_for_sqlite3_next_stmt = true;
+
         public const int SQLITE_UTF8                = 1;
         public const int SQLITE_UTF16LE             = 2;
         public const int SQLITE_UTF16BE             = 3;


### PR DESCRIPTION
This is a proof of concept that I created for changes I would like to put in place.  I see value in skipping over adding the values to the dictionary if you are not using sqlite3_next_stmt, which is why I added a flag, but to be on the safe side, I made sure the default implementation is backwards compatible with the current functionality.  

I also added implemented the ConcurrentDictionary to make sure people don't run into the same situation as issue #57 states.