### PR TITLE
net35 goes to env, but the rest should fall back from netstandard11 t…

### DIFF
--- a/gen_build.cs
+++ b/gen_build.cs
@@ -493,28 +493,32 @@ public static class projects
 
 	public static config_csproj find_core(string env)
 	{
-        config_csproj cfg = find("core", env);
+        // See https://docs.nuget.org/ndocs/schema/target-frameworks
+        config_csproj cfg;
+
+        switch (env)
+        {
+            case "net35":
+                cfg = find("core", env);
+                break;
+            case "net40":
+                cfg = find("core", "profile136");
+                break;
+            default:
+                cfg = find("core", "netstandard11");
+                if (cfg == null)
+                    cfg = find("core", "profile259");
+                if (cfg == null)
+                    cfg = find("core", "profile111");
+                break;
+        }
+
+        // as a last resort, find the matching core, e.g., net45 gets net45 core
         if (cfg == null)
         {
-            // TODO need to find a core that is compatible with env
-            // TODO this should be smarter
-            switch (env)
-            {
-                case "net40":
-                    cfg = find("core", "profile136");
-                    break;
-                case "net45":
-                    cfg = find("core", "profile111");
-                    break;
-                case "win81":
-                    cfg = find("core", "profile111");
-                    break;
-                default:
-                    cfg = find("core", "netstandard11");
-                    //cfg = find("core", "profile259");
-                    break;
-            }
+            cfg = find("core", env);
         }
+
         if (cfg != null)
         {
             return cfg;


### PR DESCRIPTION
…o profile259 to profile111

Please see if there is something to do this. Currently everything gets mapped to its own env because all core's are available.