### PR TITLE
Adds sqlite3_bind_blob overload which takes an offset into the blob to bind

### DIFF
--- a/src/cs/isqlite3.cs
+++ b/src/cs/isqlite3.cs
@@ -132,6 +132,7 @@ namespace SQLitePCL
         string sqlite3_bind_parameter_name(IntPtr stmt, int index);
         int sqlite3_bind_blob(IntPtr stmt, int index, byte[] blob);
         int sqlite3_bind_blob(IntPtr stmt, int index, byte[] blob, int nSize);
+        int sqlite3_bind_blob(IntPtr stmt, int index, byte[] blob, int offset, int nSize);
         int sqlite3_bind_double(IntPtr stmt, int index, double val);
         int sqlite3_bind_int(IntPtr stmt, int index, int val);
         int sqlite3_bind_int64(IntPtr stmt, int index, long val);

--- a/src/cs/raw.cs
+++ b/src/cs/raw.cs
@@ -714,12 +714,17 @@ namespace SQLitePCL
 
         static public int sqlite3_bind_blob(sqlite3_stmt stmt, int index, byte[] blob)
         {
-            return sqlite3_bind_blob(stmt, index, blob, blob.Length);
+            return sqlite3_bind_blob(stmt, index, blob, 0, blob.Length);
         }
 
         static public int sqlite3_bind_blob(sqlite3_stmt stmt, int index, byte[] blob, int nSize)
         {
-            return _imp.sqlite3_bind_blob(stmt.ptr, index, blob, nSize);
+            return sqlite3_bind_blob(stmt, index, blob, 0, nSize);
+        }
+
+        static public int sqlite3_bind_blob(sqlite3_stmt stmt, int index, byte[] blob, int offset, int nSize)
+        {
+            return _imp.sqlite3_bind_blob(stmt.ptr, index, blob, offset, nSize);
         }
 
         static public int sqlite3_bind_double(sqlite3_stmt stmt, int index, double val)

--- a/src/cs/sqlite3_bait.cs
+++ b/src/cs/sqlite3_bait.cs
@@ -475,6 +475,11 @@ namespace SQLitePCL
             throw new Exception(GRIPE);
         }
 
+        int ISQLite3Provider.sqlite3_bind_blob(IntPtr stm, int paramIndex, byte[] blob, int offset, int nSize)
+        {
+            throw new Exception(GRIPE);
+        }
+
         int ISQLite3Provider.sqlite3_bind_zeroblob(IntPtr stm, int paramIndex, int size)
         {
 	    throw new Exception(GRIPE);

--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -1278,13 +1278,18 @@ namespace SQLitePCL
 
         int ISQLite3Provider.sqlite3_bind_blob(IntPtr stm, int paramIndex, byte[] blob)
         {
-            return ((ISQLite3Provider)this).sqlite3_bind_blob(stm, paramIndex, blob, blob.Length);
+            return ((ISQLite3Provider)this).sqlite3_bind_blob(stm, paramIndex, blob, 0, blob.Length);
         }
 
         int ISQLite3Provider.sqlite3_bind_blob(IntPtr stm, int paramIndex, byte[] blob, int nSize)
         {
+            return ((ISQLite3Provider)this).sqlite3_bind_blob(stm, paramIndex, blob, 0, nSize);
+        }
+
+        int ISQLite3Provider.sqlite3_bind_blob(IntPtr stm, int paramIndex, byte[] blob, int offset, int nSize)
+        {
             GCHandle pinned = GCHandle.Alloc(blob, GCHandleType.Pinned);
-            IntPtr ptr = pinned.AddrOfPinnedObject();
+            IntPtr ptr = IntPtr.Add(pinned.AddrOfPinnedObject(), offset);
             int rc = SQLite3RuntimeProvider.sqlite3_bind_blob(stm.ToInt64(), paramIndex, ptr.ToInt64(), nSize, -1);
             pinned.Free();
             return rc;

--- a/src/cs/sqlite3_pinvoke.cs
+++ b/src/cs/sqlite3_pinvoke.cs
@@ -1061,6 +1061,11 @@ namespace SQLitePCL
             return NativeMethods.sqlite3_bind_blob(stm, paramIndex, blob, nSize, new IntPtr(-1));
         }
 
+        int ISQLite3Provider.sqlite3_bind_blob(IntPtr stm, int paramIndex, byte[] blob, int offset, int nSize)
+        {
+            return NativeMethods.sqlite3_bind_blob(stm, paramIndex, blob, offset, nSize, new IntPtr(-1));
+        }
+
         int ISQLite3Provider.sqlite3_bind_zeroblob(IntPtr stm, int paramIndex, int size)
         {
             return NativeMethods.sqlite3_bind_zeroblob(stm, paramIndex, size);

--- a/src/cs/ugly.cs
+++ b/src/cs/ugly.cs
@@ -544,12 +544,17 @@ namespace SQLitePCL.Ugly
 
         public static void bind_blob(this sqlite3_stmt stmt, int index, byte[] b)
         {
-            bind_blob(stmt, index, b, b.Length);
+            bind_blob(stmt, index, b, 0, b.Length);
         }
 
         public static void bind_blob(this sqlite3_stmt stmt, int index, byte[] b, int nSize)
         {
-            int rc = raw.sqlite3_bind_blob(stmt, index, b, nSize);
+            bind_blob(stmt, index, b, 0, nSize);
+        }
+
+        public static void bind_blob(this sqlite3_stmt stmt, int index, byte[] b, int offset, int nSize)
+        {
+            int rc = raw.sqlite3_bind_blob(stmt, index, b, offset, nSize);
             check_ok(rc);
         }
 


### PR DESCRIPTION
This adds the option to specify an offset into the provided byte buffer (which is what the native API would allow).
This is useful when the data to write is somewhere in a MemoryStream (with a non-zero Position).