### PR TITLE
Fixes incorrect SQLITE_ERROR

### DIFF
--- a/src/cs/sqlite3_cppinterop.cs
+++ b/src/cs/sqlite3_cppinterop.cs
@@ -1387,7 +1387,7 @@ namespace SQLitePCL
             }
 
             var length = SQLite3RuntimeProvider.sqlite3_column_bytes(stm.ToInt64(), columnIndex);
-            if (offset + length >= result.Length)
+            if (offset + length > result.Length)
             {
                 return raw.SQLITE_ERROR;
             }


### PR DESCRIPTION
This fixes an incorrect SQLITE_ERROR returned by 'sqlite3_column_blob' when the provided 'byte[]' is the same length as the column blob's length + offset