### PR TITLE
Improve .targets files for .NET Framework

### DIFF
--- a/src/SQLitePCLRaw.lib.e_sqlcipher/SQLitePCLRaw.lib.e_sqlcipher.targets
+++ b/src/SQLitePCLRaw.lib.e_sqlcipher/SQLitePCLRaw.lib.e_sqlcipher.targets
@@ -1,60 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Automatically generated-->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\e_sqlcipher.dll">
-      <Link>runtimes\win-x86\native\e_sqlcipher.dll</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Windows_NT' ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\win-*\native\e_sqlcipher.dll" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\e_sqlcipher.dll">
-      <Link>runtimes\win-x64\native\e_sqlcipher.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm\native\e_sqlcipher.dll">
-      <Link>runtimes\win-arm\native\e_sqlcipher.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libe_sqlcipher.dylib">
-      <Link>runtimes\osx-x64\native\libe_sqlcipher.dylib</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\osx-*\native\libe_sqlcipher.dylib" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' AND !Exists('/Library/Frameworks') ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-x86\native\libe_sqlcipher.so</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Unix' AND !Exists('/Library/Frameworks') ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\linux-*\native\libe_sqlcipher.so" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-x64\native\libe_sqlcipher.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-arm\native\libe_sqlcipher.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-armel\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-armel\native\libe_sqlcipher.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-arm64\native\libe_sqlcipher.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libe_sqlcipher.so">
-      <Link>runtimes\linux-x64\native\libe_sqlcipher.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/SQLitePCLRaw.lib.e_sqlite3/SQLitePCLRaw.lib.e_sqlite3.targets
+++ b/src/SQLitePCLRaw.lib.e_sqlite3/SQLitePCLRaw.lib.e_sqlite3.targets
@@ -1,60 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Automatically generated-->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\e_sqlite3.dll">
-      <Link>runtimes\win-x86\native\e_sqlite3.dll</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Windows_NT' ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\win-*\native\e_sqlite3.dll" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\e_sqlite3.dll">
-      <Link>runtimes\win-x64\native\e_sqlite3.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm\native\e_sqlite3.dll">
-      <Link>runtimes\win-arm\native\e_sqlite3.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libe_sqlite3.dylib">
-      <Link>runtimes\osx-x64\native\libe_sqlite3.dylib</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\osx-*\native\libe_sqlite3.dylib" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' AND !Exists('/Library/Frameworks') ">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libe_sqlite3.so">
-      <Link>runtimes\linux-x86\native\libe_sqlite3.so</Link>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(OS)' == 'Unix' AND !Exists('/Library/Frameworks') ">
+    <!-- Using **\runtimes here so that we can refer to runtimes\{rid}\native\ in the Link element below with %(RecursiveDir) -->
+    <SQLiteNativeLibraries Include="$(MSBuildThisFileDirectory)..\..\**\runtimes\linux-*\native\libe_sqlite3.so" />
+    <None Include="@(SQLiteNativeLibraries)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libe_sqlite3.so">
-      <Link>runtimes\linux-x64\native\libe_sqlite3.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libe_sqlite3.so">
-      <Link>runtimes\linux-arm\native\libe_sqlite3.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-armel\native\libe_sqlite3.so">
-      <Link>runtimes\linux-armel\native\libe_sqlite3.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libe_sqlite3.so">
-      <Link>runtimes\linux-arm64\native\libe_sqlite3.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libe_sqlite3.so">
-      <Link>runtimes\linux-x64\native\libe_sqlite3.so</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Pack>false</Pack>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Simplify the .targets files by adding a new `SQLiteNativeLibraries` item. This also makes it easier if, for some reason, someone wants a reference to the native SQLite libraries in their MSBuild targets (fixes #301)
* Add a condition on .NET Framework $(TargetFramework.StartsWith('net4')) because native library loading is handled automatically in .NET Core so we don't want to do extra work and risk to interfere with the .NET Core dll loading system
* Use `None` instead of `Content` (thus removing Pack=false) and set `Visible` to `false` (fixes #156)