### PR TITLE
Fix test_other_col_types when running in time zones with a positive offset from UTC

### DIFF
--- a/src/SQLitePCLRaw.ugly/ugly.cs
+++ b/src/SQLitePCLRaw.ugly/ugly.cs
@@ -853,7 +853,7 @@ namespace SQLitePCL.Ugly
                     {
                         DateTime d = (DateTime)a[i];
                         DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
-                        TimeSpan diff = d.ToUniversalTime() - origin;
+                        TimeSpan diff = d - origin;
                         stmt.bind_int64(ndx, (long)diff.TotalSeconds);
                     }
                     else if (typeof(byte[]) == t)

--- a/src/SQLitePCLRaw.ugly/ugly.cs
+++ b/src/SQLitePCLRaw.ugly/ugly.cs
@@ -708,7 +708,7 @@ namespace SQLitePCL.Ugly
             }
             else if (typeof(DateTime) == t)
             {
-                DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+                DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                 return origin.AddSeconds(stmt.column_int64(index));
             }
             else if (
@@ -853,7 +853,7 @@ namespace SQLitePCL.Ugly
                     {
                         DateTime d = (DateTime)a[i];
                         DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
-                        TimeSpan diff = d - origin;
+                        TimeSpan diff = d.ToUniversalTime() - origin;
                         stmt.bind_int64(ndx, (long)diff.TotalSeconds);
                     }
                     else if (typeof(byte[]) == t)

--- a/src/common/tests_xunit.cs
+++ b/src/common/tests_xunit.cs
@@ -1809,7 +1809,7 @@ namespace SQLitePCL.Tests
                 db.exec("INSERT INTO foo (id,n,r) VALUES (?,?,?)", 2, 44, null);
                 db.exec("INSERT INTO foo (id,n,r) VALUES (?,?,?)", 3, null, 1.414);
                 db.exec("INSERT INTO foo (id,n,r) VALUES (?,?,?)", 4, 0, null);
-                db.exec("INSERT INTO foo (id,n,r) VALUES (?,?,?)", 5, new DateTime(1968, 3, 15), null);
+                db.exec("INSERT INTO foo (id,n,r) VALUES (?,?,?)", 5, new DateTime(1968, 3, 15, 0, 0, 0, DateTimeKind.Utc), null);
                 using (sqlite3_stmt stmt = db.prepare("SELECT n,r FROM foo WHERE id=1;"))
                 {
                     stmt.step();
@@ -1900,7 +1900,15 @@ namespace SQLitePCL.Tests
 
                     {
                         var v = stmt.column<DateTime>(0);
-                        Assert.Equal(new DateTime(1968, 3, 15), v);
+                        Assert.Equal(1968, v.Year);
+                        Assert.Equal(3, v.Month);
+                        Assert.Equal(15, v.Day);
+                        Assert.Equal(0, v.Hour);
+                        Assert.Equal(0, v.Minute);
+                        Assert.Equal(0, v.Second);
+                        Assert.Equal(0, v.Millisecond);
+                        // Can't use Assert.Equal on a DateTimeKind enum because fake_xunit's Assert.Equal<T> has a constraint on "T : class" that xunit doesn't have
+                        Assert.Equal((int)DateTimeKind.Utc, (int)v.Kind);
                     }
                 }
                 using (sqlite3_stmt stmt = db.prepare("SELECT n,r FROM foo WHERE id=5;"))

--- a/src/common/tests_xunit.cs
+++ b/src/common/tests_xunit.cs
@@ -1900,9 +1900,7 @@ namespace SQLitePCL.Tests
 
                     {
                         var v = stmt.column<DateTime>(0);
-                        Assert.Equal(1968, v.Year);
-                        Assert.Equal(3, v.Month);
-                        Assert.Equal(15, v.Day);
+                        Assert.Equal(new DateTime(1968, 3, 15), v);
                     }
                 }
                 using (sqlite3_stmt stmt = db.prepare("SELECT n,r FROM foo WHERE id=5;"))


### PR DESCRIPTION
This test would only pass when run in time zones with a negative offset from UTC. Since the test only asserts on year, month and day, the test passes. When run in a timezone with a positive offset from UTC, the day would change. For example, in UTC+2, the date would become 1968-03-14T22:00:00.0000000 and the test would fail (14 != 15).

By doing `d.ToUniversalTime()` the time of the supplied DateTime was changed and the stored date was actually altered (by its offset from UTC). Asserting on the whole date would fail:
>    Assert.Equal() Failure  
> Expected: 1968-03-15T00:00:00.0000000  
> Actual:   1968-03-15T08:00:00.0000000  

The assertion has been changed to assert on the full DateTime and the code was fixed to not alter the supplied date. So now, `test_other_col_types` always passes, no matter what `TimeZoneInfo.Local` is.