### PR TITLE
Improve Library not found exception message

### DIFF
--- a/src/SQLitePCLRaw.nativelibrary/for_netstandard2.cs
+++ b/src/SQLitePCLRaw.nativelibrary/for_netstandard2.cs
@@ -26,6 +26,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace SQLitePCL
@@ -79,10 +80,12 @@ namespace SQLitePCL
 
         public static IntPtr Load(string libraryName, System.Reflection.Assembly assy, int flags)
         {
-            var h = MyLoad(libraryName, assy, flags, s => { });
+            var logWriter = new StringWriter();
+            logWriter.WriteLine($"Library {libraryName} not found");
+            var h = MyLoad(libraryName, assy, flags, s => logWriter.WriteLine(s));
             if (h == IntPtr.Zero)
             {
-                throw new Exception($"Library {libraryName} not found");
+                throw new Exception(logWriter.ToString());
             }
             return h;
         }
@@ -388,10 +391,10 @@ namespace SQLitePCL
             var suffix = WhichLibSuffix();
             log($"suffix: {suffix}");
             var a = MakePossibilitiesFor(basename, assy, flags, suffix);
-            log("possibilities:");
-            foreach (var s in a)
+            log($"possibilities ({a.Count}):");
+            foreach (var (s, i) in a.Select((s, i) => (s, i)))
             {
-                log($"    {s}");
+                log($"    {i+1}) {s}");
             }
             if (Search(a, plat, log, out var lib, out var h))
             {


### PR DESCRIPTION
Before this commit, has a vague error message.

```
System.Exception : Library e_sqlite3 not found
```

After this commit, has a precise error message helping to diagnose why the library was not found.

```
System.Exception : Library e_sqlite3 not found
plat: dlopen
suffix: DYLIB
possibilities (1):
    1) /private/var/folders/km/h0s9nvsd1n58sbrn2wjsf1h80000gn/T/5b2c1131-f872-40fb-80f8-0913973a3f0f/5b2c1131-f872-40fb-80f8-0913973a3f0f/assembly/shadow/9253aac8/fb1d192a_694eb3e2_00000002/runtimes/osx-x64/native/libe_sqlite3.dylib
dlopen TryLoad: /private/var/folders/km/h0s9nvsd1n58sbrn2wjsf1h80000gn/T/5b2c1131-f872-40fb-80f8-0913973a3f0f/5b2c1131-f872-40fb-80f8-0913973a3f0f/assembly/shadow/9253aac8/fb1d192a_694eb3e2_00000002/runtimes/osx-x64/native/libe_sqlite3.dylib
dlopen gave: 0
NOT FOUND
```

Having this additional information would have spared me some time diagnosing the [shadow copy issue when running tests](https://github.com/dotnet/efcore/issues/19396#issuecomment-683874998).