### PR TITLE
Restore version with pre-{timestamp} format

### DIFF
--- a/version_stamp/version_stamp.cs
+++ b/version_stamp/version_stamp.cs
@@ -51,7 +51,7 @@ public static class gen
         );
 
     // chg this to be the version string we want, one of the above
-    public static string NUSPEC_VERSION = NUSPEC_VERSION_RELEASE;
+    public static string NUSPEC_VERSION = NUSPEC_VERSION_PRE_TIMESTAMP;
 
     public static string ASSEMBLY_VERSION = string.Format("{0}.{1}.{2}.{3}",
         MAJOR_VERSION,


### PR DESCRIPTION
Now that version 2.0.4 is released, use the pre format with a timestamp to avoid overwriting the real 2.0.4 NuGet packages in the global packages (i.e. %userprofile%\.nuget\packages or ~/.nuget/packages).