### PR TITLE
Add SQLitePCLRaw.bundle_green dependencies for .NET 6

### DIFF
--- a/src/SQLitePCLRaw.bundle_green/SQLitePCLRaw.bundle_green.nuspec
+++ b/src/SQLitePCLRaw.bundle_green/SQLitePCLRaw.bundle_green.nuspec
@@ -19,7 +19,16 @@
         <dependency id="SQLitePCLRaw.core" version="$version$" />
         <dependency id="SQLitePCLRaw.provider.dynamic_cdecl" version="$version$" />
       </group>
+      <group targetFramework="net6.0-ios">
+        <dependency id="SQLitePCLRaw.core" version="$version$" />
+        <dependency id="SQLitePCLRaw.provider.dynamic_cdecl" version="$version$" />
+      </group>
       <group targetFramework="MonoAndroid80">
+        <dependency id="SQLitePCLRaw.core" version="$version$" />
+        <dependency id="SQLitePCLRaw.provider.e_sqlite3" version="$version$" />
+        <dependency id="SQLitePCLRaw.lib.e_sqlite3.android" version="$version$" />
+      </group>
+      <group targetFramework="net6.0-android">
         <dependency id="SQLitePCLRaw.core" version="$version$" />
         <dependency id="SQLitePCLRaw.provider.e_sqlite3" version="$version$" />
         <dependency id="SQLitePCLRaw.lib.e_sqlite3.android" version="$version$" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5366

In fixing test using `sqlite-net-pcl` in .NET 6 on Android, I found
that `SQLitePCLRaw.bundle_green` is preferring the `netcoreapp3.1`
dependencies over the `monoandroid8.0` ones.

I could workaround the problem by adding a `<PackageReference/>`:

    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3.android" Version="2.0.4" />

Then at least some simple C# code that creates a table works in .NET 6
(on Android). If we add more target frameworks for `net6.0-android`
and `net6.0-ios`, the existing Xamarin NuGet packages should pretty
much work in .NET 6.

This may not build at all, depending on the NuGet version being used
here, but I thought this could at least get the conversation going.

If you want to try out things in a real app, try:

https://github.com/xamarin/net6-samples

Let me know if you have other thoughts, thanks!