### PR TITLE
Add sqlite3_keyword_count and sqlite3_keyword_name

### DIFF
--- a/src/SQLitePCLRaw.core/isqlite3.cs
+++ b/src/SQLitePCLRaw.core/isqlite3.cs
@@ -254,6 +254,9 @@ namespace SQLitePCL
 
 
         int sqlite3_win32_set_directory(int typ, utf8z path);
+
+		int sqlite3_keyword_count();
+		int sqlite3_keyword_name(int i, out string name);
     }
 }
 

--- a/src/SQLitePCLRaw.core/raw.cs
+++ b/src/SQLitePCLRaw.core/raw.cs
@@ -1329,6 +1329,16 @@ namespace SQLitePCL
         {
             return Provider.sqlite3_win32_set_directory(typ, path.to_utf8z());
         }
+
+		static public int sqlite3_keyword_count()
+		{
+			return Provider.sqlite3_keyword_count();
+		}
+
+		static public int sqlite3_keyword_name(int i, out string name)
+		{
+			return Provider.sqlite3_keyword_name(i, out name);
+		}
     }
 }
 

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -49,6 +49,7 @@ namespace SQLitePCL
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
 	using System.Reflection;
+	using System.Text;
 
 	[Preserve(AllMembers = true)]
     public sealed class SQLite3Provider_<#= NAME #> : ISQLite3Provider
@@ -1493,6 +1494,20 @@ namespace SQLitePCL
             }
         }
 
+		int ISQLite3Provider.sqlite3_keyword_count()
+		{
+			return NativeMethods.sqlite3_keyword_count();
+		}
+
+		unsafe int ISQLite3Provider.sqlite3_keyword_name(int i, out string name)
+		{
+			var rc = NativeMethods.sqlite3_keyword_name(i, out var p_name, out var length);
+
+			// p_name is NOT null-terminated
+			name = Encoding.UTF8.GetString(p_name, length);
+			return rc;
+		}
+
 	static class NativeMethods
 	{
 <#
@@ -1669,6 +1684,8 @@ namespace SQLitePCL
 		"sqlite3_wal_checkpoint_v2",
 		"sqlite3_set_authorizer",
 		"sqlite3_win32_set_directory8",
+		"sqlite3_keyword_count",
+		"sqlite3_keyword_name",
 	};
 #>
 		static Delegate Load(IGetFunctionPointer gf, Type delegate_type)
@@ -2209,6 +2226,11 @@ namespace SQLitePCL
 		<#= attr #>
 		<#= front #> int sqlite3_create_function_v2(sqlite3 db, byte[] strName, int nArgs, int nType, hook_handle pvUser, NativeMethods.callback_scalar_function func, NativeMethods.callback_agg_function_step fstep, NativeMethods.callback_agg_function_final ffinal, NativeMethods.callback_destroy fdestroy);
 
+		<#= attr #>
+		<#= front #> int sqlite3_keyword_count();
+
+		<#= attr #>
+		<#= front #> int sqlite3_keyword_name(int i, out byte *name, out int length);
 <#+
 	}
 #>


### PR DESCRIPTION
Need this to light up `connection.GetSchema(DbMetaDataCollectionNames.ReservedWords)`. Definentally not a priority.