### PR TITLE
Add support for linux-ppc64le target

### DIFF
--- a/gen_lib_nuspecs/Program.cs
+++ b/gen_lib_nuspecs/Program.cs
@@ -418,6 +418,7 @@ public static class gen
 
         write_nuspec_file_entry_native_linux(lib, "mips64", "linux-mips64", f);
         write_nuspec_file_entry_native_linux(lib, "s390x", "linux-s390x", f);
+	write_nuspec_file_entry_native_linux(lib, "ppc64le", "linux-ppc64le", f);
 
         write_nuspec_file_entry_native_wasm(lib, TFM.NET60, f);
         write_nuspec_file_entry_native_wasm(lib, TFM.NET70, f);
@@ -692,6 +693,7 @@ public static class gen
             write_nuget_prop_item("linux-x64", lib, f);
             write_nuget_prop_item("linux-mips64", lib, f);
             write_nuget_prop_item("linux-s390x", lib, f);
+	    write_nuget_prop_item("linux-ppc64le", lib, f);
             f.WriteEndElement(); // PropertyGroup
 
             f.WriteEndElement(); // Project


### PR DESCRIPTION
This PR consists of the changes to support ppc64le target.