### PR TITLE
added sqlite3_serialize() and sqlite3_deserialize() (src)

### DIFF
--- a/src/SQLitePCLRaw.core/isqlite3.cs
+++ b/src/SQLitePCLRaw.core/isqlite3.cs
@@ -246,6 +246,8 @@ namespace SQLitePCL
         int sqlite3_stricmp(IntPtr p, IntPtr q);
         int sqlite3_strnicmp(IntPtr p, IntPtr q, int n);
 
+        IntPtr sqlite3_malloc(int n);
+        IntPtr sqlite3_malloc64(ulong n);
         void sqlite3_free(IntPtr p);
 
         int sqlite3_key(sqlite3 db, ReadOnlySpan<byte> key);
@@ -276,6 +278,9 @@ namespace SQLitePCL
 
 		int sqlite3_keyword_count();
 		int sqlite3_keyword_name(int i, out string name);
+
+        IntPtr sqlite3_serialize(sqlite3 db, utf8z schema, out long size, uint flags);
+        int sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, uint flags);
     }
 }
 

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -205,6 +205,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(ulong n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -1788,6 +1798,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, uint flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, uint flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
 <#
@@ -2179,6 +2205,13 @@ namespace SQLitePCL
             "sqlite3_malloc",
             new Parm[] {
                 new Parm("int", "n"),
+            }
+            ),
+        new Function(
+            "IntPtr",
+            "sqlite3_malloc64",
+            new Parm[] {
+                new Parm("ulong", "n"),
             }
             ),
         new Function(
@@ -3149,6 +3182,28 @@ namespace SQLitePCL
                 new Parm("int", "i"),
                 new Parm("byte*", "name").SetIsOut(true),
                 new Parm("int", "length").SetIsOut(true),
+            }
+            ),
+        new Function(
+            "IntPtr",
+            "sqlite3_serialize",
+            new Parm[] {
+                new Parm("sqlite3", "db"),
+                new Parm("byte*", "schema"),
+                new Parm("long", "size").SetIsOut(true),
+                new Parm("uint", "flags"),
+            }
+            ),
+        new Function(
+            "int",
+            "sqlite3_deserialize",
+            new Parm[] {
+                new Parm("sqlite3", "db"),
+                new Parm("byte*", "schema"),
+                new Parm("IntPtr", "data"),
+                new Parm("long", "szDb"),
+                new Parm("long", "szBuf"),
+                new Parm("uint", "flags"),
             }
             ),
 


### PR DESCRIPTION
Opening this PR for discussion.  I'm not sure about the approach, or if there are additional requirements to get a change like this accepted.

The `raw` additions seem heavy compared to its other methods, but I tried to take a similar stance of handling all memory management there.  Since the sqlite flags for these functions are related to memory management, they are not exposed in the raw api.  The support for Stream is a simple, standard way to avoid a buffer, but it is a new reference to System.IO.