### PR TITLE
Add sqlite3_serialize and sqlite3_deserialize

### DIFF
--- a/gen_lib_nuspecs/Program.cs
+++ b/gen_lib_nuspecs/Program.cs
@@ -406,15 +406,9 @@ public static class gen
         write_nuspec_file_entry_native_linux(lib, "armsf", "linux-armel", f);
         write_nuspec_file_entry_native_linux(lib, "arm64", "linux-arm64", f);
 
-        // TODO seems sad to put two copies of each musl, one for linux-musl- RID and one for alpine- RID
         write_nuspec_file_entry_native_linux(lib, "musl-x64", "linux-musl-x64", f);
         write_nuspec_file_entry_native_linux(lib, "musl-armhf", "linux-musl-arm", f);
         write_nuspec_file_entry_native_linux(lib, "musl-arm64", "linux-musl-arm64", f);
-
-        // TODO seems sad to put two copies of each musl, one for linux-musl- RID and one for alpine- RID
-        write_nuspec_file_entry_native_linux(lib, "musl-x64", "alpine-x64", f);
-        write_nuspec_file_entry_native_linux(lib, "musl-armhf", "alpine-arm", f);
-        write_nuspec_file_entry_native_linux(lib, "musl-arm64", "alpine-arm64", f);
 
         write_nuspec_file_entry_native_linux(lib, "mips64", "linux-mips64", f);
         write_nuspec_file_entry_native_linux(lib, "s390x", "linux-s390x", f);

--- a/src/SQLitePCLRaw.core/isqlite3.cs
+++ b/src/SQLitePCLRaw.core/isqlite3.cs
@@ -53,7 +53,7 @@ namespace SQLitePCL
     /// boundary between the portable class library and the platform-specific code
     /// below.
     ///
-    /// In general, it is defined to be as low-level as possible while still remaninig
+    /// In general, it is defined to be as low-level as possible while still remaining
     /// "portable".  For example, a sqlite3 connection handle appears here as an IntPtr.
     /// Same goes for the C-level sqlite3_stmt pointer, also an IntPtr.
     ///
@@ -246,6 +246,8 @@ namespace SQLitePCL
         int sqlite3_stricmp(IntPtr p, IntPtr q);
         int sqlite3_strnicmp(IntPtr p, IntPtr q, int n);
 
+        IntPtr sqlite3_malloc(int n);
+        IntPtr sqlite3_malloc64(long n);
         void sqlite3_free(IntPtr p);
 
         int sqlite3_key(sqlite3 db, ReadOnlySpan<byte> key);
@@ -276,6 +278,9 @@ namespace SQLitePCL
 
 		int sqlite3_keyword_count();
 		int sqlite3_keyword_name(int i, out string name);
+
+        IntPtr sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags);
+        int sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags);
     }
 }
 

--- a/src/SQLitePCLRaw.core/raw.cs
+++ b/src/SQLitePCLRaw.core/raw.cs
@@ -1500,19 +1500,19 @@ namespace SQLitePCL
 			return Provider.sqlite3_keyword_name(i, out name);
 		}
 
-        static public void sqlite3_malloc(int n)
+        static public IntPtr sqlite3_malloc(int n)
         {
             return Provider.sqlite3_malloc(n);
         }
 
-        static public void sqlite3_malloc64(long n)
+        static public IntPtr sqlite3_malloc64(long n)
         {
             return Provider.sqlite3_malloc64(n);
         }
 
         static public void sqlite3_free(IntPtr p)
         {
-            return Provider.sqlite3_free(p);
+            Provider.sqlite3_free(p);
         }
 
         static public IntPtr sqlite3_serialize(sqlite3 db, string schema, out long size, int flags)

--- a/src/SQLitePCLRaw.core/raw.cs
+++ b/src/SQLitePCLRaw.core/raw.cs
@@ -339,6 +339,11 @@ namespace SQLitePCL
         public const int SQLITE_TRACE_ROW = 0x04;
         public const int SQLITE_TRACE_CLOSE = 0x08;
 
+        public const int SQLITE_SERIALIZE_NOCOPY = 1; /* SQLite will not allocate memory. */
+        public const int SQLITE_DESERIALIZE_FREEONCLOSE = 1; /* SQLite will call sqlite3_free() on close. */
+        public const int SQLITE_DESERIALIZE_RESIZEABLE = 2; /* SQLite will resize using sqlite3_realloc64(). */
+        public const int SQLITE_DESERIALIZE_READONLY = 4; /* Database is read-only. */
+
         static public int sqlite3_open(utf8z filename, out sqlite3 db)
         {
             int rc = Provider.sqlite3_open(filename, out var p_db);
@@ -1494,5 +1499,30 @@ namespace SQLitePCL
 		{
 			return Provider.sqlite3_keyword_name(i, out name);
 		}
+
+        static public void sqlite3_malloc(int n)
+        {
+            return Provider.sqlite3_malloc(n);
+        }
+
+        static public void sqlite3_malloc64(long n)
+        {
+            return Provider.sqlite3_malloc64(n);
+        }
+
+        static public void sqlite3_free(IntPtr p)
+        {
+            return Provider.sqlite3_free(p);
+        }
+
+        static public IntPtr sqlite3_serialize(sqlite3 db, string schema, out long size, int flags)
+        {
+            return Provider.sqlite3_serialize(db, schema.to_utf8z(), out size, flags);
+        }
+
+        static public int sqlite3_deserialize(sqlite3 db, string schema, IntPtr data, long deserializedDataSize, long maxDataSize, int flags)
+        {
+            return Provider.sqlite3_deserialize(db, schema.to_utf8z(), data, deserializedDataSize, maxDataSize, flags);
+        }
     }
 }

--- a/src/SQLitePCLRaw.lib.e_sqlcipher/SQLitePCLRaw.lib.e_sqlcipher.nuspec
+++ b/src/SQLitePCLRaw.lib.e_sqlcipher/SQLitePCLRaw.lib.e_sqlcipher.nuspec
@@ -35,9 +35,6 @@
     <file src="$cb_bin_path$\e_sqlcipher\linux\musl-x64\libe_sqlcipher.so" target="runtimes\linux-musl-x64\native\libe_sqlcipher.so" />
     <file src="$cb_bin_path$\e_sqlcipher\linux\musl-armhf\libe_sqlcipher.so" target="runtimes\linux-musl-arm\native\libe_sqlcipher.so" />
     <file src="$cb_bin_path$\e_sqlcipher\linux\musl-arm64\libe_sqlcipher.so" target="runtimes\linux-musl-arm64\native\libe_sqlcipher.so" />
-    <file src="$cb_bin_path$\e_sqlcipher\linux\musl-x64\libe_sqlcipher.so" target="runtimes\alpine-x64\native\libe_sqlcipher.so" />
-    <file src="$cb_bin_path$\e_sqlcipher\linux\musl-armhf\libe_sqlcipher.so" target="runtimes\alpine-arm\native\libe_sqlcipher.so" />
-    <file src="$cb_bin_path$\e_sqlcipher\linux\musl-arm64\libe_sqlcipher.so" target="runtimes\alpine-arm64\native\libe_sqlcipher.so" />
     <file src="$cb_bin_path$\e_sqlcipher\linux\mips64\libe_sqlcipher.so" target="runtimes\linux-mips64\native\libe_sqlcipher.so" />
     <file src="$cb_bin_path$\e_sqlcipher\linux\s390x\libe_sqlcipher.so" target="runtimes\linux-s390x\native\libe_sqlcipher.so" />
     <file src="$cb_bin_path$\e_sqlcipher\linux\ppc64le\libe_sqlcipher.so" target="runtimes\linux-ppc64le\native\libe_sqlcipher.so" />

--- a/src/SQLitePCLRaw.lib.e_sqlite3/SQLitePCLRaw.lib.e_sqlite3.nuspec
+++ b/src/SQLitePCLRaw.lib.e_sqlite3/SQLitePCLRaw.lib.e_sqlite3.nuspec
@@ -35,9 +35,6 @@
     <file src="$cb_bin_path$\e_sqlite3\linux\musl-x64\libe_sqlite3.so" target="runtimes\linux-musl-x64\native\libe_sqlite3.so" />
     <file src="$cb_bin_path$\e_sqlite3\linux\musl-armhf\libe_sqlite3.so" target="runtimes\linux-musl-arm\native\libe_sqlite3.so" />
     <file src="$cb_bin_path$\e_sqlite3\linux\musl-arm64\libe_sqlite3.so" target="runtimes\linux-musl-arm64\native\libe_sqlite3.so" />
-    <file src="$cb_bin_path$\e_sqlite3\linux\musl-x64\libe_sqlite3.so" target="runtimes\alpine-x64\native\libe_sqlite3.so" />
-    <file src="$cb_bin_path$\e_sqlite3\linux\musl-armhf\libe_sqlite3.so" target="runtimes\alpine-arm\native\libe_sqlite3.so" />
-    <file src="$cb_bin_path$\e_sqlite3\linux\musl-arm64\libe_sqlite3.so" target="runtimes\alpine-arm64\native\libe_sqlite3.so" />
     <file src="$cb_bin_path$\e_sqlite3\linux\mips64\libe_sqlite3.so" target="runtimes\linux-mips64\native\libe_sqlite3.so" />
     <file src="$cb_bin_path$\e_sqlite3\linux\s390x\libe_sqlite3.so" target="runtimes\linux-s390x\native\libe_sqlite3.so" />
     <file src="$cb_bin_path$\e_sqlite3\linux\ppc64le\libe_sqlite3.so" target="runtimes\linux-ppc64le\native\libe_sqlite3.so" />

--- a/src/SQLitePCLRaw.provider.dynamic_cdecl/Generated/provider_dynamic_cdecl.cs
+++ b/src/SQLitePCLRaw.provider.dynamic_cdecl/Generated/provider_dynamic_cdecl.cs
@@ -135,6 +135,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -708,7 +718,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1519,6 +1529,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
 		static Delegate Load(IGetFunctionPointer gf, Type delegate_type)
@@ -1586,6 +1612,7 @@ namespace SQLitePCL
 			sqlite3_threadsafe = (MyDelegateTypes.sqlite3_threadsafe) Load(gf, typeof(MyDelegateTypes.sqlite3_threadsafe));
 			sqlite3_sourceid = (MyDelegateTypes.sqlite3_sourceid) Load(gf, typeof(MyDelegateTypes.sqlite3_sourceid));
 			sqlite3_malloc = (MyDelegateTypes.sqlite3_malloc) Load(gf, typeof(MyDelegateTypes.sqlite3_malloc));
+			sqlite3_malloc64 = (MyDelegateTypes.sqlite3_malloc64) Load(gf, typeof(MyDelegateTypes.sqlite3_malloc64));
 			sqlite3_realloc = (MyDelegateTypes.sqlite3_realloc) Load(gf, typeof(MyDelegateTypes.sqlite3_realloc));
 			sqlite3_free = (MyDelegateTypes.sqlite3_free) Load(gf, typeof(MyDelegateTypes.sqlite3_free));
 			sqlite3_stricmp = (MyDelegateTypes.sqlite3_stricmp) Load(gf, typeof(MyDelegateTypes.sqlite3_stricmp));
@@ -1701,6 +1728,8 @@ namespace SQLitePCL
 			sqlite3_create_function_v2 = (MyDelegateTypes.sqlite3_create_function_v2) Load(gf, typeof(MyDelegateTypes.sqlite3_create_function_v2));
 			sqlite3_keyword_count = (MyDelegateTypes.sqlite3_keyword_count) Load(gf, typeof(MyDelegateTypes.sqlite3_keyword_count));
 			sqlite3_keyword_name = (MyDelegateTypes.sqlite3_keyword_name) Load(gf, typeof(MyDelegateTypes.sqlite3_keyword_name));
+			sqlite3_serialize = (MyDelegateTypes.sqlite3_serialize) Load(gf, typeof(MyDelegateTypes.sqlite3_serialize));
+			sqlite3_deserialize = (MyDelegateTypes.sqlite3_deserialize) Load(gf, typeof(MyDelegateTypes.sqlite3_deserialize));
 		}
 
 		public static MyDelegateTypes.sqlite3_close sqlite3_close;
@@ -1739,6 +1768,7 @@ namespace SQLitePCL
 		public static MyDelegateTypes.sqlite3_threadsafe sqlite3_threadsafe;
 		public static MyDelegateTypes.sqlite3_sourceid sqlite3_sourceid;
 		public static MyDelegateTypes.sqlite3_malloc sqlite3_malloc;
+		public static MyDelegateTypes.sqlite3_malloc64 sqlite3_malloc64;
 		public static MyDelegateTypes.sqlite3_realloc sqlite3_realloc;
 		public static MyDelegateTypes.sqlite3_free sqlite3_free;
 		public static MyDelegateTypes.sqlite3_stricmp sqlite3_stricmp;
@@ -1854,6 +1884,8 @@ namespace SQLitePCL
 		public static MyDelegateTypes.sqlite3_create_function_v2 sqlite3_create_function_v2;
 		public static MyDelegateTypes.sqlite3_keyword_count sqlite3_keyword_count;
 		public static MyDelegateTypes.sqlite3_keyword_name sqlite3_keyword_name;
+		public static MyDelegateTypes.sqlite3_serialize sqlite3_serialize;
+		public static MyDelegateTypes.sqlite3_deserialize sqlite3_deserialize;
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);
 
@@ -2006,6 +2038,9 @@ namespace SQLitePCL
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate IntPtr sqlite3_malloc(int n);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate IntPtr sqlite3_malloc64(long n);
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -2362,6 +2397,12 @@ namespace SQLitePCL
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.dynamic_stdcall/Generated/provider_dynamic_stdcall.cs
+++ b/src/SQLitePCLRaw.provider.dynamic_stdcall/Generated/provider_dynamic_stdcall.cs
@@ -135,6 +135,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -708,7 +718,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1519,6 +1529,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
 		static Delegate Load(IGetFunctionPointer gf, Type delegate_type)
@@ -1586,6 +1612,7 @@ namespace SQLitePCL
 			sqlite3_threadsafe = (MyDelegateTypes.sqlite3_threadsafe) Load(gf, typeof(MyDelegateTypes.sqlite3_threadsafe));
 			sqlite3_sourceid = (MyDelegateTypes.sqlite3_sourceid) Load(gf, typeof(MyDelegateTypes.sqlite3_sourceid));
 			sqlite3_malloc = (MyDelegateTypes.sqlite3_malloc) Load(gf, typeof(MyDelegateTypes.sqlite3_malloc));
+			sqlite3_malloc64 = (MyDelegateTypes.sqlite3_malloc64) Load(gf, typeof(MyDelegateTypes.sqlite3_malloc64));
 			sqlite3_realloc = (MyDelegateTypes.sqlite3_realloc) Load(gf, typeof(MyDelegateTypes.sqlite3_realloc));
 			sqlite3_free = (MyDelegateTypes.sqlite3_free) Load(gf, typeof(MyDelegateTypes.sqlite3_free));
 			sqlite3_stricmp = (MyDelegateTypes.sqlite3_stricmp) Load(gf, typeof(MyDelegateTypes.sqlite3_stricmp));
@@ -1701,6 +1728,8 @@ namespace SQLitePCL
 			sqlite3_create_function_v2 = (MyDelegateTypes.sqlite3_create_function_v2) Load(gf, typeof(MyDelegateTypes.sqlite3_create_function_v2));
 			sqlite3_keyword_count = (MyDelegateTypes.sqlite3_keyword_count) Load(gf, typeof(MyDelegateTypes.sqlite3_keyword_count));
 			sqlite3_keyword_name = (MyDelegateTypes.sqlite3_keyword_name) Load(gf, typeof(MyDelegateTypes.sqlite3_keyword_name));
+			sqlite3_serialize = (MyDelegateTypes.sqlite3_serialize) Load(gf, typeof(MyDelegateTypes.sqlite3_serialize));
+			sqlite3_deserialize = (MyDelegateTypes.sqlite3_deserialize) Load(gf, typeof(MyDelegateTypes.sqlite3_deserialize));
 		}
 
 		public static MyDelegateTypes.sqlite3_close sqlite3_close;
@@ -1739,6 +1768,7 @@ namespace SQLitePCL
 		public static MyDelegateTypes.sqlite3_threadsafe sqlite3_threadsafe;
 		public static MyDelegateTypes.sqlite3_sourceid sqlite3_sourceid;
 		public static MyDelegateTypes.sqlite3_malloc sqlite3_malloc;
+		public static MyDelegateTypes.sqlite3_malloc64 sqlite3_malloc64;
 		public static MyDelegateTypes.sqlite3_realloc sqlite3_realloc;
 		public static MyDelegateTypes.sqlite3_free sqlite3_free;
 		public static MyDelegateTypes.sqlite3_stricmp sqlite3_stricmp;
@@ -1854,6 +1884,8 @@ namespace SQLitePCL
 		public static MyDelegateTypes.sqlite3_create_function_v2 sqlite3_create_function_v2;
 		public static MyDelegateTypes.sqlite3_keyword_count sqlite3_keyword_count;
 		public static MyDelegateTypes.sqlite3_keyword_name sqlite3_keyword_name;
+		public static MyDelegateTypes.sqlite3_serialize sqlite3_serialize;
+		public static MyDelegateTypes.sqlite3_deserialize sqlite3_deserialize;
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);
 
@@ -2006,6 +2038,9 @@ namespace SQLitePCL
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate IntPtr sqlite3_malloc(int n);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate IntPtr sqlite3_malloc64(long n);
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -2362,6 +2397,12 @@ namespace SQLitePCL
 
 		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 		public unsafe delegate int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[UnmanagedFunctionPointer(CALLING_CONVENTION)]
+		public unsafe delegate int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_funcptrs_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_funcptrs_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -699,7 +709,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1510,6 +1520,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlcipher";
@@ -1621,6 +1647,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1963,6 +1992,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_funcptrs_win.cs
@@ -130,6 +130,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -703,7 +713,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly (CallConvs = new[] { typeof(CallConvCdecl) })]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1514,6 +1524,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlcipher";
@@ -1625,6 +1651,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1970,6 +1999,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_prenet5_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_prenet5_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -693,7 +703,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1504,6 +1514,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlcipher";
@@ -1612,6 +1638,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1954,6 +1983,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_prenet5_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlcipher/Generated/provider_e_sqlcipher_prenet5_win.cs
@@ -129,6 +129,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -696,7 +706,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1507,6 +1517,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlcipher";
@@ -1615,6 +1641,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1960,6 +1989,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -687,7 +697,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1498,6 +1508,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlite3";
@@ -1609,6 +1635,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1939,6 +1968,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
@@ -130,6 +130,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -691,7 +701,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly (CallConvs = new[] { typeof(CallConvCdecl) })]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1502,6 +1512,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlite3";
@@ -1613,6 +1639,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1946,6 +1975,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -681,7 +691,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1492,6 +1502,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlite3";
@@ -1600,6 +1626,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1930,6 +1959,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_win.cs
@@ -129,6 +129,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -684,7 +694,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1495,6 +1505,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "e_sqlite3";
@@ -1603,6 +1629,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1936,6 +1965,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.internal/Generated/provider_internal_funcptrs.cs
+++ b/src/SQLitePCLRaw.provider.internal/Generated/provider_internal_funcptrs.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -693,7 +703,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1504,6 +1514,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "__Internal";
@@ -1612,6 +1638,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1954,6 +1983,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.internal/Generated/provider_internal_legacy.cs
+++ b/src/SQLitePCLRaw.provider.internal/Generated/provider_internal_legacy.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -693,7 +703,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1504,6 +1514,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "__Internal";
@@ -1612,6 +1638,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1954,6 +1983,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_funcptrs_notwin.cs
+++ b/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_funcptrs_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -699,7 +709,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1510,6 +1520,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlcipher";
@@ -1621,6 +1647,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1963,6 +1992,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_funcptrs_win.cs
@@ -130,6 +130,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -703,7 +713,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly (CallConvs = new[] { typeof(CallConvCdecl) })]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1514,6 +1524,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlcipher";
@@ -1625,6 +1651,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1970,6 +1999,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_prenet5_notwin.cs
+++ b/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_prenet5_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -693,7 +703,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1504,6 +1514,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlcipher";
@@ -1612,6 +1638,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1954,6 +1983,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_prenet5_win.cs
+++ b/src/SQLitePCLRaw.provider.sqlcipher/Generated/provider_sqlcipher_prenet5_win.cs
@@ -129,6 +129,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -696,7 +706,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1507,6 +1517,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlcipher";
@@ -1615,6 +1641,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1960,6 +1989,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_funcptrs_notwin.cs
+++ b/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_funcptrs_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -687,7 +697,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1498,6 +1508,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlite3";
@@ -1609,6 +1635,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1939,6 +1968,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_funcptrs_win.cs
@@ -130,6 +130,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -691,7 +701,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [UnmanagedCallersOnly (CallConvs = new[] { typeof(CallConvCdecl) })]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1502,6 +1512,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlite3";
@@ -1613,6 +1639,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1946,6 +1975,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	}
 

--- a/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_prenet5_notwin.cs
+++ b/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_prenet5_notwin.cs
@@ -126,6 +126,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -681,7 +691,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1492,6 +1502,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlite3";
@@ -1600,6 +1626,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1930,6 +1959,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_prenet5_win.cs
+++ b/src/SQLitePCLRaw.provider.sqlite3/Generated/provider_sqlite3_prenet5_win.cs
@@ -129,6 +129,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -684,7 +694,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1495,6 +1505,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "sqlite3";
@@ -1603,6 +1629,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1936,6 +1965,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/SQLitePCLRaw.provider.winsqlite3/Generated/provider_winsqlite3.cs
+++ b/src/SQLitePCLRaw.provider.winsqlite3/Generated/provider_winsqlite3.cs
@@ -129,6 +129,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            return NativeMethods.sqlite3_malloc64(n);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -684,7 +694,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         [MonoPInvokeCallback (typeof(NativeMethods.callback_log))]
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)
@@ -1495,6 +1505,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
         private const string SQLITE_DLL = "winsqlite3";
@@ -1603,6 +1629,9 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_malloc(int n);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_malloc64(long n);
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe IntPtr sqlite3_realloc(IntPtr p, int n);
@@ -1936,6 +1965,12 @@ namespace SQLitePCL
 
 		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
 		public static extern unsafe int sqlite3_keyword_name(int i, out byte* name, out int length);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe IntPtr sqlite3_serialize(sqlite3 db, byte* schema, out long size, int flags);
+
+		[DllImport(SQLITE_DLL, ExactSpelling=true, CallingConvention = CALLING_CONVENTION)]
+		public static extern unsafe int sqlite3_deserialize(sqlite3 db, byte* schema, IntPtr data, long szDb, long szBuf, int flags);
 
 	[UnmanagedFunctionPointer(CALLING_CONVENTION)]
 	public delegate void callback_log(IntPtr pUserData, int errorCode, IntPtr pMessage);

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -212,7 +212,7 @@ namespace SQLitePCL
 
         IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
         {
-            NativeMethods.sqlite3_malloc64(p);
+            return NativeMethods.sqlite3_malloc64(p);
         }
 
         void ISQLite3Provider.sqlite3_free(IntPtr p)

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -212,7 +212,7 @@ namespace SQLitePCL
 
         IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
         {
-            return NativeMethods.sqlite3_malloc64(p);
+            return NativeMethods.sqlite3_malloc64(n);
         }
 
         void ISQLite3Provider.sqlite3_free(IntPtr p)

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -205,6 +205,16 @@ namespace SQLitePCL
 			return rc;
         }
 
+        IntPtr ISQLite3Provider.sqlite3_malloc(int n)
+        {
+            return NativeMethods.sqlite3_malloc(n);
+        }
+
+        IntPtr ISQLite3Provider.sqlite3_malloc64(long n)
+        {
+            NativeMethods.sqlite3_malloc64(p);
+        }
+
         void ISQLite3Provider.sqlite3_free(IntPtr p)
         {
             NativeMethods.sqlite3_free(p);
@@ -1788,6 +1798,22 @@ namespace SQLitePCL
 			return rc;
 		}
 
+        unsafe IntPtr ISQLite3Provider.sqlite3_serialize(sqlite3 db, utf8z schema, out long size, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_serialize(db, p_schema, out size, flags);
+            }
+        }
+
+        unsafe int ISQLite3Provider.sqlite3_deserialize(sqlite3 db, utf8z schema, IntPtr data, long szDb, long szBuf, int flags)
+        {
+            fixed (byte* p_schema = schema)
+            {
+                return NativeMethods.sqlite3_deserialize(db, p_schema, data, szDb, szBuf, flags);
+            }
+        }
+
 	static class NativeMethods
 	{
 <#
@@ -2179,6 +2205,13 @@ namespace SQLitePCL
             "sqlite3_malloc",
             new Parm[] {
                 new Parm("int", "n"),
+            }
+            ),
+        new Function(
+            "IntPtr",
+            "sqlite3_malloc64",
+            new Parm[] {
+                new Parm("long", "n"),
             }
             ),
         new Function(
@@ -3149,6 +3182,28 @@ namespace SQLitePCL
                 new Parm("int", "i"),
                 new Parm("byte*", "name").SetIsOut(true),
                 new Parm("int", "length").SetIsOut(true),
+            }
+            ),
+        new Function(
+            "IntPtr",
+            "sqlite3_serialize",
+            new Parm[] {
+                new Parm("sqlite3", "db"),
+                new Parm("byte*", "schema"),
+                new Parm("long", "size").SetIsOut(true),
+                new Parm("int", "flags")
+            }
+            ),
+        new Function(
+            "int",
+            "sqlite3_deserialize",
+            new Parm[] {
+                new Parm("sqlite3", "db"),
+                new Parm("byte*", "schema"),
+                new Parm("IntPtr", "data"),
+                new Parm("long", "szDb")
+                new Parm("long", "szBuf")
+                new Parm("int", "flags")
             }
             ),
 

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -3201,8 +3201,8 @@ namespace SQLitePCL
                 new Parm("sqlite3", "db"),
                 new Parm("byte*", "schema"),
                 new Parm("IntPtr", "data"),
-                new Parm("long", "szDb")
-                new Parm("long", "szBuf")
+                new Parm("long", "szDb"),
+                new Parm("long", "szBuf"),
                 new Parm("int", "flags")
             }
             ),

--- a/src/t2/tests.csproj
+++ b/src/t2/tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
 	<ProjectReference Include="..\SQLitePCLRaw.core\SQLitePCLRaw.core.csproj" />

--- a/src/tests/tests.csproj
+++ b/src/tests/tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
 	<ProjectReference Include="..\SQLitePCLRaw.core\SQLitePCLRaw.core.csproj" />

--- a/test_nupkgs/device/Droid/App18.csproj
+++ b/test_nupkgs/device/Droid/App18.csproj
@@ -23,6 +23,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/test_nupkgs/device/UWP/App19.csproj
+++ b/test_nupkgs/device/UWP/App19.csproj
@@ -29,6 +29,7 @@
     <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
     <UapDefaultAssetScale>100</UapDefaultAssetScale>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/test_nupkgs/device/iOS/tests.csproj
+++ b/test_nupkgs/device/iOS/tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>tests</RootNamespace>
     <AssemblyName>tests</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test_nupkgs/device/macOS/mactest.csproj
+++ b/test_nupkgs/device/macOS/mactest.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test_nupkgs/e_sqlcipher/fake_xunit/e_sqlcipher_with_fake_xunit.csproj
+++ b/test_nupkgs/e_sqlcipher/fake_xunit/e_sqlcipher_with_fake_xunit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
       <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>

--- a/test_nupkgs/e_sqlcipher/real_xunit/e_sqlcipher_with_real_xunit.csproj
+++ b/test_nupkgs/e_sqlcipher/real_xunit/e_sqlcipher_with_real_xunit.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
       <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>

--- a/test_nupkgs/e_sqlite3/classic_dotnet_framework/ConsoleApp1.csproj
+++ b/test_nupkgs/e_sqlite3/classic_dotnet_framework/ConsoleApp1.csproj
@@ -31,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test_nupkgs/e_sqlite3/fake_xunit/e_sqlite3_with_fake_xunit.csproj
+++ b/test_nupkgs/e_sqlite3/fake_xunit/e_sqlite3_with_fake_xunit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1;net6.0;net6.0-windows</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
       <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>

--- a/test_nupkgs/e_sqlite3/real_xunit/e_sqlite3_with_real_xunit.csproj
+++ b/test_nupkgs/e_sqlite3/real_xunit/e_sqlite3_with_real_xunit.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
       <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>

--- a/test_nupkgs/sqlite3/fake_xunit/sqlite3_with_fake_xunit.csproj
+++ b/test_nupkgs/sqlite3/fake_xunit/sqlite3_with_fake_xunit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="sqlitepclraw.bundle_sqlite3" Version="$(pkg_version_for_testing)" />

--- a/test_nupkgs/winsqlite3/fake_xunit/winsqlite3_with_fake_xunit.csproj
+++ b/test_nupkgs/winsqlite3/fake_xunit/winsqlite3_with_fake_xunit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="sqlitepclraw.bundle_winsqlite3" Version="$(pkg_version_for_testing)" />

--- a/test_nupkgs/winsqlite3/real_xunit/winsqlite3_with_real_xunit.csproj
+++ b/test_nupkgs/winsqlite3/real_xunit/winsqlite3_with_real_xunit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <!-- TODO for some reason, including net461 here fails with Test Aborted and no details given -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="microsoft.net.test.sdk" Version="$(depversion_microsoft_net_test_sdk)" />

--- a/todo.txt
+++ b/todo.txt
@@ -54,9 +54,6 @@ sqlite3_normalized_sql
 
 sqlite3_value_frombind
 
-sqlite3_serialize
-sqlite3_deserialize
-
 sqlite3_keyword_count/name/check
 
 need 3 ways of doing dynamic load:


### PR DESCRIPTION
Closes #530.

This also exposes `sqlite3_malloc`, `sqlite3_malloc64`, and `sqlite3_free` because these are necessary for consumers to fully utilize the serialization functions.

For `sqlite3_deserialize` I decided to take `IntPtr` and `long` size parameters instead of a `ReadOnlySpan<byte>` as I originally wanted to do because spans only have an `int` Length property, which would cap the database size at 2 GB. I did not want to impose that sort of artificial limitation.