### PR TITLE
fix for e_sqlite3 not found for vsto apps.

### DIFF
--- a/src/common/batteries_v2.cs
+++ b/src/common/batteries_v2.cs
@@ -102,7 +102,7 @@ namespace SQLitePCL
 #elif PROVIDER_dynamic
 
 #if PROVIDER_NAME_e_sqlite3
-		    DoDynamic_cdecl("e_sqlite3", NativeLibrary.WHERE_RUNTIME_RID | NativeLibrary.WHERE_ADJACENT);
+		    DoDynamic_cdecl("e_sqlite3", NativeLibrary.WHERE_RUNTIME_RID | NativeLibrary.WHERE_ADJACENT | NativeLibrary.WHERE_CODEBASE);
 #elif PROVIDER_NAME_e_sqlcipher
 		    DoDynamic_cdecl("e_sqlcipher", NativeLibrary.WHERE_RUNTIME_RID | NativeLibrary.WHERE_ADJACENT);
 #elif PROVIDER_NAME_sqlcipher

--- a/src/common/nativelibrary_defines.cs
+++ b/src/common/nativelibrary_defines.cs
@@ -24,6 +24,7 @@ namespace SQLitePCL
         public const int WHERE_RUNTIME_RID = 0x02;
         public const int WHERE_ARCH = 0x04;
         public const int WHERE_ADJACENT = 0x08;
+        public const int WHERE_CODEBASE = 0x10;
     }
 }
 

--- a/src/common/nativelibrary_for_netstandard2.cs
+++ b/src/common/nativelibrary_for_netstandard2.cs
@@ -370,6 +370,11 @@ namespace SQLitePCL
                 a.Add(Path.Combine(dir, libname));
             }
 
+            if ((flags & WHERE_CODEBASE) != 0) {
+               var dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
+               a.Add(Path.Combine(dir, libname));
+            }
+
             return a;
         }
 

--- a/src/common/nativelibrary_for_netstandard2.cs
+++ b/src/common/nativelibrary_for_netstandard2.cs
@@ -370,7 +370,8 @@ namespace SQLitePCL
                 a.Add(Path.Combine(dir, libname));
             }
 
-            if ((flags & WHERE_CODEBASE) != 0) {
+            if ((flags & WHERE_CODEBASE) != 0) 
+            {
                var dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
                a.Add(new Uri(Path.Combine(dir, libname)).AbsolutePath);
             }

--- a/src/common/nativelibrary_for_netstandard2.cs
+++ b/src/common/nativelibrary_for_netstandard2.cs
@@ -372,7 +372,7 @@ namespace SQLitePCL
 
             if ((flags & WHERE_CODEBASE) != 0) {
                var dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
-               a.Add(Path.Combine(dir, libname));
+               a.Add(new Uri(Path.Combine(dir, libname)).AbsolutePath);
             }
 
             return a;

--- a/src/common/nativelibrary_for_netstandard2.cs
+++ b/src/common/nativelibrary_for_netstandard2.cs
@@ -370,10 +370,12 @@ namespace SQLitePCL
                 a.Add(Path.Combine(dir, libname));
             }
 
-            if ((flags & WHERE_CODEBASE) != 0) 
+            if ((flags & WHERE_CODEBASE) != 0 &&
+                RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework")
+               ) 
             {
-               var dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
-               a.Add(new Uri(Path.Combine(dir, libname)).AbsolutePath);
+                var dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase);
+                a.Add(new Uri(Path.Combine(dir, libname)).AbsolutePath);
             }
 
             return a;


### PR DESCRIPTION
Problem:
In issue #552 I identified that VSTO is copying SQLitePCLRaw.core.DLL to `C:\Users\username\AppData\Local\assembly\dl3\<HASH_STRINGS>\ SQLitePCLRaw.core.DLL` but was not copying `e_sqlite3.dll` with it. `SQLitePCLRaw.core.DLL` is expecting to find `e_sqlite3.dll` in the same directory level as itself or a few levels down from it at `<same_path>\runtimes\{os-arch}\native\e_sqlite3.dll` For VSTO apps nothing is copying the native dependency over. so e_sqlite3.dll isn't propogated.

The Fix: 

using `System.Reflection.Assembly.GetExecutingAssembly().CodeBase` we can get the original path of the copied over binary. This will be the same path where `e_sqlite.dll` lives. Using `Path.GetDirectoryName` We get the path without the base name and build out a path using `Path.Combine` and the ` libname`.

We define a new flag in `NativeLibrary` called `WHERE_CODEBASE` that will let us have a third option for lookup of `e_sqlite3` providers.

I'm limiting to just `e_sqlite3` Because that is the library used by the App Center C# sdk. 
