### PR TITLE
Handle zero-length `Span` inputs for `sqlite3_bind_text*`

### DIFF
--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -1553,7 +1553,13 @@ namespace SQLitePCL
         {
             fixed (byte* p_t = t)
             {
-                return NativeMethods.sqlite3_bind_text(stm, paramIndex, p_t, t.Length, new IntPtr(-1));
+                // passing a zero-length span to sqlite3_bind_text() requires
+                // a non-null pointer, even though conceptually, that pointer
+                // point to zero things, ie nothing. for that case, pass the
+                // address of `dummy` instead.
+                
+                byte dummy = 0;
+                return NativeMethods.sqlite3_bind_text(stm, paramIndex, p_t != null ? p_t : &dummy, t.Length, new IntPtr(-1));
             }
         }
 
@@ -1561,8 +1567,14 @@ namespace SQLitePCL
         {
             fixed (char* p_t = t)
             {
+                // passing a zero-length span to sqlite3_bind_text() requires
+                // a non-null pointer, even though conceptually, that pointer
+                // point to zero things, ie nothing. for that case, pass the
+                // address of `dummy` instead.
+                
+                char dummy = '\0';
                 // mul span length times 2 to get num bytes, which is what sqlite wants
-                return NativeMethods.sqlite3_bind_text16(stm, paramIndex, p_t, t.Length * 2, new IntPtr(-1));
+                return NativeMethods.sqlite3_bind_text16(stm, paramIndex, p_t != null ? p_t : &dummy, t.Length * 2, new IntPtr(-1));
             }
         }
 
@@ -1581,25 +1593,15 @@ namespace SQLitePCL
 
         unsafe int ISQLite3Provider.sqlite3_bind_blob(sqlite3_stmt stm, int paramIndex, ReadOnlySpan<byte> blob)
         {
-            if (blob.Length == 0)
+            fixed (byte* p = blob)
             {
                 // passing a zero-length blob to sqlite3_bind_blob() requires
                 // a non-null pointer, even though conceptually, that pointer
-                // point to zero things, ie nothing.
-
-                var ba_fake = new byte[] { 42 };
-                ReadOnlySpan<byte> span_fake = ba_fake;
-                fixed (byte* p_fake = span_fake)
-                {
-                    return NativeMethods.sqlite3_bind_blob(stm, paramIndex, p_fake, 0, new IntPtr(-1));
-                }
-            }
-            else
-            {
-                fixed (byte* p = blob)
-                {
-                    return NativeMethods.sqlite3_bind_blob(stm, paramIndex, p, blob.Length, new IntPtr(-1));
-                }
+                // point to zero things, ie nothing. for that case, pass the
+                // address of `dummy` instead.
+                
+                byte dummy = 0;
+                return NativeMethods.sqlite3_bind_blob(stm, paramIndex, p != null ? p : &dummy, blob.Length, new IntPtr(-1));
             }
         }
 


### PR DESCRIPTION
Same as `sqlite3_bind_blob`, the SQLite C APIs `sqlite3_bind_text*` require the data pointer argument to be non-null to actually accept zero-length input. Otherwise, when a null data pointer is passed, the explicit length is ignored and a `SQLITE_NULL` value is bound instead.

This PR updates `sqlite3_bind_text` and `sqlite3_bind_text16` to handle zero-length `ReadOnlySpan`s, by substituting a valid pointer for the zero-length case. 

The generated `sqlite3_bind_blob` code already handled this scenario by allocating a new `byte[]` for each call e.g. at:

https://github.com/ericsink/SQLitePCL.raw/blob/9c66b4f618d9d6831e83c16a8036daea83df4ddb/src/providers/provider.tt#L1586-L1595

This PR proposes a potentially lower-overhead solution (passing the address of a local) for both `sqlite3_bind_text*` and `sqlite3_bind_blob`, as suggested by [`Span<T>` usage Rule #9](https://learn.microsoft.com/en-us/dotnet/standard/memory-and-spans/memory-t-usage-guidelines):

> *In the previous example, `pbData` can be null if, for example, **the input span is empty**. If the exported method absolutely requires that `pbData` be non-null, even if `cbData` is 0, the method can be implemented as follows*

These changes address the `sqlite3_bind_text*` functions behavior when called with empty `ReadOnlySpan`.

Fixes https://github.com/ericsink/SQLitePCL.raw/issues/557
