### PR TITLE
Address CA1859

### DIFF
--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -977,7 +977,7 @@ namespace SQLitePCL
 
         // ----------------------------------------------------------------
 
-		static IDisposable disp_log_hook_handle;
+		static hook_handle disp_log_hook_handle;
 
         <#= get_monopinvokecallback_attr("log") #>
         static void log_hook_bridge_impl(IntPtr p, int rc, IntPtr s)


### PR DESCRIPTION
> warning CA1859: Change type of field 'disp_log_hook_handle' from 'System.IDisposable' to 'SQLitePCL.hook_handle?' for improved performance (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859)