### PR TITLE
Add support for linux-musl-s390x target

### DIFF
--- a/gen_lib_nuspecs/Program.cs
+++ b/gen_lib_nuspecs/Program.cs
@@ -413,6 +413,7 @@ public static class gen
         write_nuspec_file_entry_native_linux(lib, "musl-x64", "linux-musl-x64", f);
         write_nuspec_file_entry_native_linux(lib, "musl-armhf", "linux-musl-arm", f);
         write_nuspec_file_entry_native_linux(lib, "musl-arm64", "linux-musl-arm64", f);
+        write_nuspec_file_entry_native_linux(lib, "musl-s390x", "linux-musl-s390x", f);
 
         write_nuspec_file_entry_native_linux(lib, "mips64", "linux-mips64", f);
         write_nuspec_file_entry_native_linux(lib, "s390x", "linux-s390x", f);


### PR DESCRIPTION
This implements the rest of https://github.com/ericsink/SQLitePCL.raw/issues/571, after the "cb" part (https://github.com/ericsink/cb/pull/21) is merged.