### PR TITLE
Update SQLitePCLRaw.lib.e_sqlite3.targets

### DIFF
--- a/src/SQLitePCLRaw.lib.e_sqlite3/net461/SQLitePCLRaw.lib.e_sqlite3.targets
+++ b/src/SQLitePCLRaw.lib.e_sqlite3/net461/SQLitePCLRaw.lib.e_sqlite3.targets
@@ -17,6 +17,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\e_sqlite3.dll">
+      <Link>runtimes\win-arm64\native\e_sqlite3.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>false</Pack>
+    </Content>
   </ItemGroup>
   <ItemGroup Condition=" '$(RuntimeIdentifier)' == '' AND '$(OS)' == 'Unix' AND Exists('/Library/Frameworks') ">
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libe_sqlite3.dylib">


### PR DESCRIPTION
Missing content for win-arm64 in nuget targets

The win-arm64 are missing in the output directory