### PR TITLE
Suppress WASM0001 for browser-wasm consumers

### DIFF
--- a/src/SQLitePCLRaw.provider.e_sqlite3/SQLitePCLRaw.provider.e_sqlite3.csproj
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/SQLitePCLRaw.provider.e_sqlite3.csproj
@@ -10,8 +10,10 @@
     <PackageDescription>SQLitePCLRaw is a Portable Class Library (PCL) for low-level (raw) access to SQLite.  Packages named 'SQLitePCLRaw.provider.*' (like this one) are 'plugins' that allow SQLitePCLRaw.core to access the native SQLite library.  This provider does DllImport of 'e_sqlite3', the SQLite builds provided with SQLitePCLRaw.</PackageDescription>
   </PropertyGroup>
 
+
 <ItemGroup>
 	<ProjectReference Include="..\SQLitePCLRaw.core\SQLitePCLRaw.core.csproj" />
+	<None Include="build\SQLitePCLRaw.provider.e_sqlite3.targets" Pack="true" PackagePath="build\" />
 </ItemGroup>
 
 <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/SQLitePCLRaw.provider.e_sqlite3/build/SQLitePCLRaw.provider.e_sqlite3.targets
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/build/SQLitePCLRaw.provider.e_sqlite3.targets
@@ -1,0 +1,13 @@
+<Project>
+  <!--
+    Suppress WASM0001 for browser-wasm consumers.
+
+    The native sqlite3_config() and sqlite3_db_config() functions use C varargs,
+    which WASM does not support. The managed wrappers in this library guard
+    against calling them on browser-wasm by throwing PlatformNotSupportedException,
+    so the warning is safe to suppress.
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' or '$(UsingBrowserRuntimeWorkload)' == 'true'">
+    <NoWarn>$(NoWarn);WASM0001</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/SQLitePCLRaw.provider.e_sqlite3/build/SQLitePCLRaw.provider.e_sqlite3.targets
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/build/SQLitePCLRaw.provider.e_sqlite3.targets
@@ -3,9 +3,7 @@
     Suppress WASM0001 for browser-wasm consumers.
 
     The native sqlite3_config() and sqlite3_db_config() functions use C varargs,
-    which WASM does not support. The managed wrappers in this library guard
-    against calling them on browser-wasm by throwing PlatformNotSupportedException,
-    so the warning is safe to suppress.
+    which WASM does not support. Ignore the warning.
   -->
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' or '$(UsingBrowserRuntimeWorkload)' == 'true'">
     <NoWarn>$(NoWarn);WASM0001</NoWarn>


### PR DESCRIPTION
The native sqlite3_config() and sqlite3_db_config() functions use C varargs, which WASM does not support. This ships a .targets file with the NuGet package that automatically suppresses WASM0001 for browser-wasm consumers.

Fixes #644 