### PR TITLE
Follow-ups to pzTail bounds-check: funcptrs_win v3-span backfill + string-overload AOOR guard

### DIFF
--- a/src/SQLitePCLRaw.core/raw.cs
+++ b/src/SQLitePCLRaw.core/raw.cs
@@ -830,7 +830,8 @@ namespace SQLitePCL
             var ba = sql.to_utf8_with_z();
             var sp = new ReadOnlySpan<byte>(ba);
             int rc = sqlite3_prepare_v2(db, sp, out stmt, out var sp_tail);
-            tail = utf8_span_to_string(sp_tail.Slice(0, sp_tail.Length - 1));
+            // Audit #1: provider now returns an empty span on error; guard Slice(0, -1).
+            tail = sp_tail.Length > 0 ? utf8_span_to_string(sp_tail.Slice(0, sp_tail.Length - 1)) : "";
             return rc;
         }
 
@@ -874,7 +875,8 @@ namespace SQLitePCL
             var ba = sql.to_utf8_with_z();
             var sp = new ReadOnlySpan<byte>(ba);
             int rc = sqlite3_prepare_v3(db, sp, flags, out stmt, out var sp_tail);
-            tail = utf8_span_to_string(sp_tail.Slice(0, sp_tail.Length - 1));
+            // Audit #1: provider now returns an empty span on error; guard Slice(0, -1).
+            tail = sp_tail.Length > 0 ? utf8_span_to_string(sp_tail.Slice(0, sp_tail.Length - 1)) : "";
             return rc;
         }
 

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_notwin.cs
@@ -270,11 +270,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v2(db, p_sql, sql.Length, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {
@@ -301,11 +301,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v3(db, p_sql, sql.Length, flags, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
@@ -304,11 +304,12 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v3(db, p_sql, sql.Length, flags, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                // Follow-up to 854eeb0: funcptrs_win's v3 span variant was missed in that commit — same p_tail bounds guard as the other three provider variants.
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs
@@ -273,11 +273,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v2(db, p_sql, sql.Length, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_notwin.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_notwin.cs
@@ -269,11 +269,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v2(db, p_sql, sql.Length, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {
@@ -300,11 +300,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v3(db, p_sql, sql.Length, flags, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_win.cs
+++ b/src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_prenet5_win.cs
@@ -272,11 +272,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v2(db, p_sql, sql.Length, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {
@@ -303,11 +303,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v3(db, p_sql, sql.Length, flags, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/common/tests_xunit.cs
+++ b/src/common/tests_xunit.cs
@@ -433,6 +433,64 @@ namespace SQLitePCL.Tests
             GC.KeepAlive(rolling);
         }
 
+        // Audit #1: the string overloads of prepare_v2/v3 used to throw
+        // ArgumentOutOfRangeException on the same MISUSE path because they
+        // unconditionally sliced the (now empty) tail span.  These tests
+        // assert they return rc cleanly with an empty tail string instead.
+        [Fact]
+        public void test_prepare_v2_string_tolerates_uninitialised_pzTail()
+        {
+            var rolling = new byte[256][];
+            var rnd = new Random(42);
+            for (var i = 0; i < 512; i++)
+            {
+                rolling[i % rolling.Length] = new byte[rnd.Next(1024, 128 * 1024)];
+
+                var db = ugly.open(":memory:");
+                db.manual_close_v2();
+                try
+                {
+                    int rc = raw.sqlite3_prepare_v2(db, "SELECT 1;", out var stmt, out string tail);
+
+                    Assert.Equal(raw.SQLITE_MISUSE, rc);
+                    Assert.Equal("", tail);
+                    stmt?.Dispose();
+                }
+                finally
+                {
+                    db.Dispose();
+                }
+            }
+            GC.KeepAlive(rolling);
+        }
+
+        [Fact]
+        public void test_prepare_v3_string_tolerates_uninitialised_pzTail()
+        {
+            var rolling = new byte[256][];
+            var rnd = new Random(42);
+            for (var i = 0; i < 512; i++)
+            {
+                rolling[i % rolling.Length] = new byte[rnd.Next(1024, 128 * 1024)];
+
+                var db = ugly.open(":memory:");
+                db.manual_close_v2();
+                try
+                {
+                    int rc = raw.sqlite3_prepare_v3(db, "SELECT 1;", 0, out var stmt, out string tail);
+
+                    Assert.Equal(raw.SQLITE_MISUSE, rc);
+                    Assert.Equal("", tail);
+                    stmt?.Dispose();
+                }
+                finally
+                {
+                    db.Dispose();
+                }
+            }
+            GC.KeepAlive(rolling);
+        }
+
         [Fact]
         public void test_bind_parameter_index()
         {

--- a/src/common/tests_xunit.cs
+++ b/src/common/tests_xunit.cs
@@ -349,6 +349,90 @@ namespace SQLitePCL.Tests
             }
         }
 
+        // Regression test for the ArgumentOutOfRangeException variant of the
+        // long-standing prepare-race bug class (see issues #108, #321, #430,
+        // #479, #588). The provider's span overload of sqlite3_prepare_v2
+        // computes `(int)(p_tail - p_sql)` and uses it as a Slice start.
+        //
+        // On SQLITE_MISUSE paths (unsafe db handle, null zSql), native returns
+        // without writing *pzTail, leaving the caller's `out byte* p_tail`
+        // local at its .locals-init default of 0. For a non-empty SQL input,
+        // p_sql is a real non-null pointer, so `p_tail - p_sql` is a 64-bit
+        // signed difference that truncates to an int whose sign depends on
+        // bit 31 of the low 32 bits of p_sql. When bit 31 is clear (the sql
+        // buffer sits at a typical high managed-heap address on x64), the
+        // cast produces a large negative int, and `sql.Slice(negative, ...)`
+        // throws ArgumentOutOfRangeException instead of cleanly returning
+        // the error rc to the caller.
+        //
+        // We trigger the unsafe-db path deterministically via manual_close_v2,
+        // and we force the sql buffer into the bit-31-clear address range by
+        // growing the heap with a rolling allocator before each iteration.
+        // On a fresh process the heap can start either side of 2^31, so
+        // without the rolling growth the test is stochastic. With it, every
+        // iteration fires the bug on unpatched builds.
+        //
+        // The patched provider bounds-checks p_tail against
+        // [p_sql, p_sql + sql.Length] before computing the slice, so this
+        // returns rc=SQLITE_MISUSE + tail=Empty instead of throwing.
+        [Fact]
+        public void test_prepare_v2_span_tolerates_uninitialised_pzTail()
+        {
+            var rolling = new byte[256][];
+            var rnd = new Random(42);
+            for (var i = 0; i < 512; i++)
+            {
+                rolling[i % rolling.Length] = new byte[rnd.Next(1024, 128 * 1024)];
+
+                var db = ugly.open(":memory:");
+                db.manual_close_v2();
+                try
+                {
+                    var sql = u.to_utf8("SELECT 1;");
+
+                    int rc = raw.sqlite3_prepare_v2(db, sql.AsSpan(), out var stmt, out var tail);
+
+                    Assert.Equal(raw.SQLITE_MISUSE, rc);
+                    Assert.True(tail.IsEmpty);
+                    stmt?.Dispose();
+                }
+                finally
+                {
+                    db.Dispose();
+                }
+            }
+            GC.KeepAlive(rolling);
+        }
+
+        [Fact]
+        public void test_prepare_v3_span_tolerates_uninitialised_pzTail()
+        {
+            var rolling = new byte[256][];
+            var rnd = new Random(42);
+            for (var i = 0; i < 512; i++)
+            {
+                rolling[i % rolling.Length] = new byte[rnd.Next(1024, 128 * 1024)];
+
+                var db = ugly.open(":memory:");
+                db.manual_close_v2();
+                try
+                {
+                    var sql = u.to_utf8("SELECT 1;");
+
+                    int rc = raw.sqlite3_prepare_v3(db, sql.AsSpan(), 0, out var stmt, out var tail);
+
+                    Assert.Equal(raw.SQLITE_MISUSE, rc);
+                    Assert.True(tail.IsEmpty);
+                    stmt?.Dispose();
+                }
+                finally
+                {
+                    db.Dispose();
+                }
+            }
+            GC.KeepAlive(rolling);
+        }
+
         [Fact]
         public void test_bind_parameter_index()
         {

--- a/src/providers/provider.tt
+++ b/src/providers/provider.tt
@@ -528,11 +528,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v2(db, p_sql, sql.Length, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {
@@ -559,11 +559,11 @@ namespace SQLitePCL
             fixed (byte* p_sql = sql)
             {
                 var rc = NativeMethods.sqlite3_prepare_v3(db, p_sql, sql.Length, flags, out stm, out var p_tail);
-                var len_consumed = (int) (p_tail - p_sql);
-                int len_remain = sql.Length - len_consumed;
-                if (len_remain > 0)
+                if (p_tail != null && p_tail >= p_sql && p_tail <= p_sql + sql.Length)
                 {
-                    tail = sql.Slice(len_consumed, len_remain);
+                    var len_consumed = (int) (p_tail - p_sql);
+                    int len_remain = sql.Length - len_consumed;
+                    tail = len_remain > 0 ? sql.Slice(len_consumed, len_remain) : ReadOnlySpan<byte>.Empty;
                 }
                 else
                 {

--- a/src/tests/my_batteries_v2.cs
+++ b/src/tests/my_batteries_v2.cs
@@ -1,5 +1,5 @@
-﻿/*
-   Copyright 2014-2019 SourceGear, LLC
+/*
+   Copyright 2014-2026 SourceGear, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,55 +14,13 @@
    limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.IO;
-
 namespace SQLitePCL
 {
     public static class Batteries_V2
     {
-        class MyGetFunctionPointer : IGetFunctionPointer
-        {
-            readonly IntPtr _dll;
-            public MyGetFunctionPointer(IntPtr dll)
-            {
-                _dll = dll;
-            }
-
-            public IntPtr GetFunctionPointer(string name)
-            {
-                if (NativeLibrary.TryGetExport(_dll, name, out var f))
-                {
-                    //System.Console.WriteLine("{0}.{1} : {2}", _dll, name, f);
-                    return f;
-                }
-                else
-                {
-                    return IntPtr.Zero;
-                }
-            }
-        }
-        static IGetFunctionPointer MakeDynamic(string name, int flags)
-        {
-            // TODO should this be GetExecutingAssembly()?
-            var assy = typeof(SQLitePCL.raw).Assembly;
-            var dll = SQLitePCL.NativeLibrary.Load(name, assy, flags);
-            var gf = new MyGetFunctionPointer(dll);
-            return gf;
-        }
-        static void DoDynamic_cdecl(string name, int flags)
-        {
-            var gf = MakeDynamic(name, flags);
-            SQLitePCL.SQLite3Provider_dynamic_cdecl.Setup(name, gf);
-            SQLitePCL.raw.SetProvider(new SQLite3Provider_dynamic_cdecl());
-        }
-
         public static void Init()
         {
-		    DoDynamic_cdecl("e_sqlite3", NativeLibrary.WHERE_PLAIN);
+            raw.SetProvider(new SQLite3Provider_e_sqlite3());
         }
     }
 }
-

--- a/src/tests/tests.csproj
+++ b/src/tests/tests.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(tfm_net)</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-	<ProjectReference Include="..\SQLitePCLRaw.core\SQLitePCLRaw.core.csproj" />
-	<ProjectReference Include="..\SQLitePCLRaw.provider.dynamic_cdecl\SQLitePCLRaw.provider.dynamic_cdecl.csproj" />
-	<ProjectReference Include="..\SQLitePCLRaw.nativelibrary\SQLitePCLRaw.nativelibrary.csproj" />
-	<!-- <ProjectReference Include="..\SQLitePCLRaw.batteries_v2.e_sqlite3.dynamic\SQLitePCLRaw.batteries_v2.e_sqlite3.dynamic.csproj" /> -->
-	<ProjectReference Include="..\SQLitePCLRaw.ugly\SQLitePCLRaw.ugly.csproj" />
+    <ProjectReference Include="..\SQLitePCLRaw.core\SQLitePCLRaw.core.csproj" />
+    <ProjectReference Include="..\SQLitePCLRaw.provider.e_sqlite3\SQLitePCLRaw.provider.e_sqlite3.csproj" />
+    <ProjectReference Include="..\SQLitePCLRaw.ugly\SQLitePCLRaw.ugly.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AltCover" Version="5.3.675" />
-    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.1.10" />
+    <PackageReference Include="SourceGear.sqlite3" Version="$(lib_e_sqlite3_package_reference_version)" />
     <PackageReference Include="microsoft.net.test.sdk" Version="$(depversion_microsoft_net_test_sdk)" />
     <PackageReference Include="xunit" Version="$(depversion_xunit)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(depversion_xunit_runner_visualstudio)" />


### PR DESCRIPTION
<!-- Draft for PR on branch fix/pztail-aoor-followups. Replace #663 with the PR0 number before submitting. -->

# Follow-ups to pzTail bounds-check: funcptrs_win v3-span backfill + string-overload AOOR guard

## Summary

Two follow-ups to #663 (the `prepare_v2`/`v3` span-overload `pzTail` bounds check):

1. `funcptrs_win.cs` drifted from `provider.tt`. That PR updated the template correctly, but the generated file wasn't re-applied for its v3 `ReadOnlySpan<byte>` overload. Sync it.
2. `raw.cs`'s `string` overloads unconditionally `Slice(0, sp_tail.Length - 1)` the provider's returned tail span. Now that #663 has the provider return an empty span on error (instead of throwing), that slice becomes `Slice(0, -1)` → `ArgumentOutOfRangeException` one layer up. Guard the slice.

## Context

#663 fixed `AccessViolationException` / `ArgumentOutOfRangeException` on the MISUSE path where `sqlite3_prepare_v2`/`v3` returns without writing `*pzTail`. It updated:

- `src/providers/provider.tt` (the T4 template)
- Three of four generated provider variants: `funcptrs_notwin`, `prenet5_win`, `prenet5_notwin`
- `raw.cs`'s `ReadOnlySpan<byte>` wrapper so callers see an empty tail on error instead of an exception

Two residual gaps:

- **`funcptrs_win.cs`** v3 span overload still has the naive slice. The template was updated by #663 but the generated file wasn't re-applied for this one overload — the commit's diff stats show 8 lines changed in `funcptrs_win.cs` vs 16 in each of the other three generated files, consistent with a partial regeneration.
- **`raw.cs`'s string overloads** still slice `sp_tail` unconditionally. Pre-#663 they never hit the issue because the provider itself threw first. Post-#663 the provider returns an empty span, and the `Slice(0, sp_tail.Length - 1)` in `raw.cs` becomes `Slice(0, -1)` → a *new* AOOR one layer up. The fix didn't fully reach the string callers.

## Changes

| File | Change |
|---|---|
| `src/SQLitePCLRaw.provider.e_sqlite3/Generated/provider_e_sqlite3_funcptrs_win.cs` | v3 `ReadOnlySpan<byte>` overload: add the `p_tail` bounds guard matching `provider.tt` and the other three generated variants |
| `src/SQLitePCLRaw.core/raw.cs` | `sqlite3_prepare_v2(string)` and `sqlite3_prepare_v3(string)`: guard the `Slice(0, sp_tail.Length - 1)` call behind `sp_tail.Length > 0` |
| `src/common/tests_xunit.cs` | Two regression tests |

## Tests

- `test_prepare_v2_string_tolerates_uninitialised_pzTail`
- `test_prepare_v3_string_tolerates_uninitialised_pzTail`

Same shape as #663's span tests: rolling heap allocations + `db.manual_close_v2()` to deterministically force MISUSE. They fire the AOOR on unpatched string-overload code; green after the fix.

`126/126` in-tree tests green on this branch.

## Stacking

This PR is **stacked on #663**. The `raw.cs` guard is functionally dependent on #663's provider change — before #663, the provider throws before `raw.cs`'s guard can run, so the guard is inert on its own. When #663 merges, I'll rebase this PR to `main`.
